### PR TITLE
Add proper link support

### DIFF
--- a/src/components/DocsLink.tsx
+++ b/src/components/DocsLink.tsx
@@ -1,0 +1,29 @@
+import { Link } from "@material-ui/core";
+import { Link as GatsbyLink } from "gatsby";
+import * as React from "react";
+import { ReactNode } from "react";
+
+type Props = {
+  href?: string;
+  children: ReactNode;
+};
+
+export function DocsLink(props: Props): JSX.Element {
+  const { href, children } = props;
+
+  if (!href) {
+    return <span>{children}</span>;
+  }
+
+  if (href.startsWith("http")) {
+    return <Link target="_blank" rel="noreferrer" variant="body1" color="textSecondary" {...props} />;
+  } else {
+    return (
+      <GatsbyLink to={href} {...props}>
+        {children}
+      </GatsbyLink>
+    );
+  }
+}
+
+export default DocsLink;

--- a/src/components/layout/Root.tsx
+++ b/src/components/layout/Root.tsx
@@ -92,6 +92,13 @@ const useStyles = makeStyles((theme) => ({
     fontSize: theme.typography.body1.fontSize,
     fontFamily: theme.typography.body1.fontFamily,
 
+    "& a": {
+      color: theme.palette.text.primary,
+      "&:hover": {
+        textDecoration: "underline",
+      },
+    },
+
     "& p": {
       marginTop: "0.75rem",
     },

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -2,11 +2,12 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { Link, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import { MDXProviderComponentsProp } from "@mdx-js/react";
 import { CodeBlock } from "@toitware/code-block";
 import React from "react";
 import Code from "./components/Code";
+import { DocsLink } from "./components/DocsLink";
 import Note from "./components/Note";
 import { Tabs } from "./components/Tabs";
 import Title from "./components/Title";
@@ -18,7 +19,6 @@ const H3 = (props: any) => <Typography variant="h3" {...props} />;
 const H4 = (props: any) => <Typography variant="h4" {...props} />;
 const H5 = (props: any) => <Typography variant="h5" {...props} />;
 const H6 = (props: any) => <Typography variant="h6" {...props} />;
-const A = (props: any) => <Link variant="body1" color="textSecondary" {...props} />;
 
 const Pre = (props: any) => <>{props.children}</>;
 
@@ -30,7 +30,7 @@ export const components: MDXProviderComponentsProp = {
   h4: H4,
   h5: H5,
   h6: H6,
-  a: A,
+  a: DocsLink,
   code: Code,
   pre: Pre,
 };


### PR DESCRIPTION
This unifies the way links are generated. Now any link that links outside the docs opens in a new tab, and using `[text](link)` or `<a href="link">text</a>` are handled exactly the same, and routed via Gatsby if local.