### PR TITLE
Remove overlong line

### DIFF
--- a/docs/tutorials/pubsub/pubsubint.mdx
+++ b/docs/tutorials/pubsub/pubsubint.mdx
@@ -23,7 +23,7 @@ topic ::= "device:hello-world"
 main:
   pubsub.subscribe topic: | msg/pubsub.Message |
     print "Received message '$msg.payload.to_string'"
-    return
+    return  // Exit 'main' (only printing one message).
 ```
 
 ## The publisher


### PR DESCRIPTION
For a simple tutorial it's also not necessary to show how the sender is established.
Also explain `return`.