### PR TITLE
More links between the language documents.

### DIFF
--- a/docs/language/blocks.mdx
+++ b/docs/language/blocks.mdx
@@ -416,7 +416,7 @@ Blocks are stack allocated, which is what makes them so efficient, but it also l
 
 - Blocks cannot be returned from functions and methods.
 
-- Lambdas cannot capture blocks.
+- [Lambdas](../tasks) cannot capture blocks.
 
 - Blocks cannot take blocks as arguments.
 

--- a/docs/language/definitions.mdx
+++ b/docs/language/definitions.mdx
@@ -201,7 +201,7 @@ glob /string := "the global 'glob' is typed as string"
 
 The type of variable is enforced by the Virtual Machine.
 Every time a value is stored in the variable, the VM checks that the type is correct.
-If it isn't, a runtime exception is thrown.
+If it isn't, a runtime [exception](../exceptions) is thrown.
 
 Types are also very helpful during development: the IDE can use the typing information to provide code completion, or warnings when types don't match.
 

--- a/docs/language/language.mdx
+++ b/docs/language/language.mdx
@@ -34,7 +34,7 @@ Hello World!
 
 What just happened? The `toit` command line tool read your source code (`hello.toit`) and started running it from the `main` method that you defined. The `main` method consists of all the indented statements just below the method declaration line `main:`. Toit is indentation-based like Python, so the spaces you add to your programs are significant.
 
-Once the program ran, it printed `Hello World!` in your terminal. This is because the only statement in `hello.toit` is a method call, where you invoke the `print` method with a single argument, which is the string to be printed (in this case to the terminal). If you wanted to output more than one line from your program, you could update it to:
+Once the program ran, it printed `Hello World!` in your terminal. This is because the only statement in `hello.toit` is a method call, where you invoke the `print` method with a single argument, which is the [string](../strings) to be printed (in this case to the terminal). If you wanted to output more than one line from your program, you could update it to:
 
 ```
 main:
@@ -265,7 +265,7 @@ class MegaGreeter:
     names.add name
 ```
 
-So MegaGreeter objects have a list of `names`. The `names` field is initialized to the empty list (`[]`). The body of the `MegaGreeter` constructor adds the given `name` argument to the end of the list of names. Notice that this is different than using a `.name` parameter that automatically assigns to the field called `name`. Mega greeters don't have a single name and no `name` field, so here the `name` is just an ordinary parameter that we can use in the body of the constructor. All in all, this code:
+So MegaGreeter objects have a [list](../listsetmap) of `names`. The `names` field is initialized to the empty list (`[]`). The body of the `MegaGreeter` constructor adds the given `name` argument to the end of the list of names. Notice that this is different than using a `.name` parameter that automatically assigns to the field called `name`. Mega greeters don't have a single name and no `name` field, so here the `name` is just an ordinary parameter that we can use in the body of the constructor. All in all, this code:
 
 ```
 main:
@@ -387,7 +387,7 @@ It is common to refer to such nested structure as _block structure_.
 
 ## Iterating over lists
 
-Let’s return to the `MegaGreeter` example and take a look at another place where constructs are block structured. In the `say_hi` method, we want to call `print` for every single name in the `names` list. We can do this by calling `names.do` and provide the list of statements we want to run for each element using block structure:
+Let’s return to the `MegaGreeter` example and take a look at another place where constructs are block structured. In the `say_hi` method, we want to call `print` for every single name in the `names` [list](../listsetmap). We can do this by calling `names.do` and provide the list of statements we want to run for each element using block structure:
 
 <!-- RESET CODE -->
 <!-- HIDDEN CODE class MegaGreeter: -->
@@ -502,9 +502,9 @@ main:
 
 This defines a top-level function called `fib` that is not a member of any class.  (We already saw `main`, which is a top level function with a special name.)
 
-The `fib` function is recursive, calling itself, and also makes use of a few new features.  The `if` statement is well known from other languages.  In Toit it works by taking an expression and conditionally evaluating a block.  Like other blocks we could have used indentation to group multiple lines.
+The `fib` function is recursive, calling itself, and also makes use of a few new features.  The [if-statement](../loops#if-statements) is well known from other languages.  In Toit it works by taking an expression and conditionally evaluating a block.  Like other blocks we could have used indentation to group multiple lines.
 
-Toit also has the usual array of infix operators, `+`, `-`, `*`, `/`, `%` etc. and the relational operators `<`, `<=`, `>`, `>=`, `==` and `!=`.  The operators have higher precedence than function arguments, so we had to group the calls in parentheses to get the desired behavior.  The high precedence is what makes the arguments for the recursive invocation of `fib` work.  We could have spaced it more conventionally and got the same effect:
+Toit also has the usual array of infix operators, `+`, `-`, `*`, `/`, `%` etc.  and the relational operators `<`, `<=`, `>`, `>=`, `==` and `!=`.  The operators have higher [precedence](../syntax#precedence) than function arguments, so we had to group the calls in parentheses to get the desired behavior.  The high precedence is what makes the arguments for the recursive invocation of `fib` work.  We could have spaced it more conventionally and got the same effect:
 
 <!-- RESET CODE -->
 ```
@@ -515,7 +515,7 @@ fib n:
 
 ## Loops
 
-This is a terribly slow way to calculate a Fibonacci number though, and we could do it with a simple loop:
+This is a terribly slow way to calculate a Fibonacci number though, and we could do it with a simple [loop](../loops#loops):
 
 ```
 fib2 n:
@@ -636,7 +636,7 @@ short_words words:
 
 The `filter` method calls the block, `it.size <= 5` for each element in the original list, and returns a new list containing only the short words.
 
-Note that there is no `return` statement in the block.  A block will return the value of the last statement to the place where it was invoked with `block.call`.  In this case there is only one statement, which is the boolean expression `it.size <= 5`.
+Note that there is no `return` statement in the block.  A block will return the value of the last statement to the place where it was invoked with `block.call`.  In this case there is only one statement, which is the [boolean](../booleans) expression `it.size <= 5`.
 
 If you use the `return` keyword in a block then it returns from the syntactic function or method in which it is written.  Usually this will behave as you would expect:
 

--- a/docs/language/listsetmap.mdx
+++ b/docs/language/listsetmap.mdx
@@ -21,6 +21,12 @@ See some examples of use of `List` and `Map` in the section [Toit blocks](../blo
 
 See also the documentation for the [List](https://libs.toit.io/core/collections/class-List), [Set](https://libs.toit.io/core/collections/class-Set), and [Map](https://libs.toit.io/core/collections/class-Map) classes.
 
+The [string](../strings) and
+[ByteArray](https://libs.toit.io/core/collections/class-ByteArray) classes are
+not subtypes of
+[Collection](https://libs.toit.io/core/collections/class-Collection), but have
+some similarities to collections.
+
 ## Set versus List versus Map
 
 - **Duplicates**: A big difference between `List` and `Set` class is that `List` allows duplicates while `Set` doesn't allow duplicates.
@@ -109,7 +115,8 @@ graduate name/string:
 ```
 
 The index operator, `[]` requires the key to be present in the map, otherwise
-it throws an exception. As an alternative, you can use the `get` method which
+it throws an [exception](../exceptions). As an alternative, you can use the
+`get` method which
 by default returns null for a missing key:
 
 ```

--- a/docs/language/objects-constructors-inheritance-interfaces.mdx
+++ b/docs/language/objects-constructors-inheritance-interfaces.mdx
@@ -22,7 +22,8 @@ class Point:
   y /int := 103
 ```
 
-Here we have given our new class two fields, with integer types, and they are
+Here we have given our new class two fields, with integer
+[types](../definitions#type), and they are
 by default initialized to 42 and 103. We create new instance objects of the
 class by naming the class, no `new` keyword is needed:
 
@@ -91,7 +92,8 @@ main:
 ### Interfaces
 
 A class can only extend one class, but can implement several
-interfaces.  Like classes, interfaces act as types in Toit's type
+interfaces.  Like classes, interfaces act as [types](../definitions#type)
+in Toit's type
 system, but unlike classes, they do not include implementations for
 the non-static methods they declare.  Since a method signature declared in an
 interface has no implementation, the colon at the end of the first
@@ -339,7 +341,7 @@ If no `super` call is present, then Toit implicitly adds
 one as late as possible. This is either at the end of the constructor body, or
 as soon the code uses `this`, a reference to the newly constructed object.
 Implicit uses of `this` also count, for example by invoking a method, or by
-creating a lambda that captures `this`.
+creating a [lambda](../tasks) that captures `this`.
 
 <!-- SKIP CODE -->
 ```


### PR DESCRIPTION
In the interests of making language features more
discoverable when I link to documents from the
Twitter @toitlang account.

We don't have a description of lambdas right now,
so I'm linking to the tasks document, which uses
them without describing them.  Needs to be fixed.