### PR TITLE
Reduce use of very long lines in .mdx

### DIFF
--- a/docs/language/blocks.mdx
+++ b/docs/language/blocks.mdx
@@ -4,7 +4,9 @@ order: 5
 
 # Toit blocks
 
-Blocks are a mechanism to conveniently and efficiently provide callbacks to functions. This mechanism is, for example, used for the methods `int.repeat` and `List.do`.
+Blocks are a mechanism to conveniently and efficiently provide callbacks to
+functions. This mechanism is, for example, used for the methods `int.repeat`
+and `List.do`.
 
 ```
 main:
@@ -20,21 +22,27 @@ main:
 Here we used the automatic block argument, `it`, [see
 below](#block-arguments)
 
-Syntactically `repeat` and `do` look like they are built-in to the language like `for` and `if` are, but they are actually normal methods that use the block feature.
+Syntactically `repeat` and `do` look like they are built-in to the language
+like `for` and `if` are, but they are actually normal methods that use the
+block feature.
 
 ## Basic use of blocks
 
-Blocks are used extensively in the Toit standard library, so you need to know the basics of calling functions that accept blocks.
-A function that takes a block as an argument surrounds the parameter with brackets `[ ]`. For example, the function signature of `int.repeat` is
+Blocks are used extensively in the Toit standard library, so you need to know
+the basics of calling functions that accept blocks.
+A function that takes a block as an argument surrounds the parameter with
+brackets `[ ]`. For example, the function signature of `int.repeat` is
 
 ```
 repeat [block]:
   // ...
 ```
 
-The `[block]` parameter states that the `repeat` function takes exactly one argument which must be a block (because of the `[` and `]`).
+The `[block]` parameter states that the `repeat` function takes exactly one
+argument which must be a block (because of the `[` and `]`).
 
-On the caller side, block arguments look like a scope for `if` or `for`. For example, if you want to call `repeat`, you could write
+On the caller side, block arguments look like a scope for `if` or `for`. For
+example, if you want to call `repeat`, you could write
 
 ```
 main:
@@ -51,7 +59,10 @@ main:
 
 ## Block arguments
 
-Blocks often receive arguments when they are called as callbacks. For instance, `List.do` iterates over a list and calls the block with every element. When the block receives one argument you can refer to the argument with the keyword `it`. For example
+Blocks often receive arguments when they are called as callbacks. For instance,
+`List.do` iterates over a list and calls the block with every element. When the
+block receives one argument you can refer to the argument with the keyword
+`it`. For example
 
 ```
 main:
@@ -67,7 +78,9 @@ John
 Sue
 ```
 
-You can name the parameter of the block if you want to use something else than `it`. To do so, you start the block with the name enclosed in pipes `|`. For example
+You can name the parameter of the block if you want to use something else than
+`it`. To do so, you start the block with the name enclosed in pipes `|`. For
+example
 
 ```
 main:
@@ -83,7 +96,10 @@ John
 Sue
 ```
 
-Some blocks receive more than one argument. In that case you have to use the `|` notation. You just write all the names in between the two pipes. For example, `Map.do` iterates all the key-value pairs of a `Map`, and calls the block with the key as the first argument and the value as the second:
+Some blocks receive more than one argument. In that case you have to use the
+`|` notation. You just write all the names in between the two pipes. For
+example, `Map.do` iterates all the key-value pairs of a `Map`, and calls the
+block with the key as the first argument and the value as the second:
 
 ```
 main:
@@ -104,11 +120,15 @@ John has ID 2345
 Sue has ID 3456
 ```
 
-If a block accepts multiple arguments, but you only need to refer to the first, then you can omit the naming and just use `it`. If there are parameters that you don't need, then you can use a wildcard `_` instead of giving them a name.
+If a block accepts multiple arguments, but you only need to refer to the first,
+then you can omit the naming and just use `it`. If there are parameters that
+you don't need, then you can use a wildcard `_` instead of giving them a name.
 
 ## Returning from blocks and accessing variables
 
-Blocks look like they are built-in which makes it important that they also act like they are built-in. This means that returning from a block with `return`, or accessing local variables must just work.
+Blocks look like they are built-in which makes it important that they also act
+like they are built-in. This means that returning from a block with `return`,
+or accessing local variables must just work.
 
 ### Non-local return
 
@@ -136,11 +156,16 @@ which would print
 -3
 ```
 
-The `return it` in `first_negative` is a non-local return which means that it doesn't just return from the block or `do`, it returns from `first_negative`. This means that we can short circuit the search when we find the first negative number.
+The `return it` in `first_negative` is a non-local return which means that it
+doesn't just return from the block or `do`, it returns from `first_negative`.
+This means that we can short circuit the search when we find the first negative
+number.
 
 ### Local return
 
-In some situations, it is useful to do a local return. That is, to just return from the block. To do this, you use the `continue` keyword followed by a dot `.` and the label of the function you want to continue in. For example
+In some situations, it is useful to do a local return. That is, to just return
+from the block. To do this, you use the `continue` keyword followed by a dot
+`.` and the label of the function you want to continue in. For example
 
 ```
 /**
@@ -165,11 +190,14 @@ which prints
 [1, 3, 3, 5]
 ```
 
-Here the block given to `map` uses `continue` to do a local return of an odd value when it sees an even value. The snippet `continue.map` can be read as "continue in the `map` function".
+Here the block given to `map` uses `continue` to do a local return of an odd
+value when it sees an even value. The snippet `continue.map` can be read as
+"continue in the `map` function".
 
 ### Default return
 
-The default return of a block is a local return. The block returns the value of the last statement in the block. For example
+The default return of a block is a local return. The block returns the value of
+the last statement in the block. For example
 
 ```
 /**
@@ -187,7 +215,9 @@ main:
 
 ```
 
-Here the block accepted by `filter` returns the value of the last statement which is `it.size < 6`, a boolean that indicates whether the size of the element is less than 6.
+Here the block accepted by `filter` returns the value of the last statement
+which is `it.size < 6`, a boolean that indicates whether the size of the
+element is less than 6.
 
 It prints
 
@@ -195,7 +225,9 @@ It prints
 [word, small, tiny]
 ```
 
-In the `oddify` example in section [Local return](#local-return), the last local return was unnecessary. If you replace `continue.map it` with `it`, then the block uses the default local return to return `it` from the block. That is
+In the `oddify` example in section [Local return](#local-return), the last
+local return was unnecessary. If you replace `continue.map it` with `it`, then
+the block uses the default local return to return `it` from the block. That is
 
 <!-- RESET CODE -->
 ```
@@ -223,7 +255,9 @@ prints
 
 ## Blocks referencing variables
 
-Blocks can reference everything that can be referenced from the scope the block was defined in. This includes access to local variable, field variables, and globals.
+Blocks can reference everything that can be referenced from the scope the block
+was defined in. This includes access to local variable, field variables, and
+globals.
 
 ```
 my_stringify list -> string:
@@ -244,7 +278,8 @@ main:
 Here the block (given to `do`) references both `is_first` and `str`.
 Notice that the block both accesses and modifies the variables.
 
-The function returns a string representation of the list corresponding to the exact syntactic construct that creates a list, and thus prints
+The function returns a string representation of the list corresponding to the
+exact syntactic construct that creates a list, and thus prints
 
 ```txt
  [1, 2, 3]
@@ -252,7 +287,9 @@ The function returns a string representation of the list corresponding to the ex
 
 ## Examples of block usage
 
-Many `for`-loops follow a common pattern, where the loop uses a loop-variable to count from 0 to a given limit. For example say you want a function that prints the numbers from 1 to `n`, you could write
+Many `for`-loops follow a common pattern, where the loop uses a loop-variable
+to count from 0 to a given limit. For example say you want a function that
+prints the numbers from 1 to `n`, you could write
 
 ```
 /// Prints the numbers from 1 to $n on separate lines.
@@ -264,7 +301,10 @@ main:
     print_numbers 5
 ```
 
-As you can see, the `for`-loop is mostly boilerplate code. All you want to express is that the `print` statement should be executed `n` times. This is where blocks come in handy. We can rewrite the above snippet using `int.repeat`:
+As you can see, the `for`-loop is mostly boilerplate code. All you want to
+express is that the `print` statement should be executed `n` times. This is
+where blocks come in handy. We can rewrite the above snippet using
+`int.repeat`:
 
 <!-- RESET CODE -->
 ```
@@ -304,7 +344,10 @@ main:
   print_list [1, 2, 3, 4, 5]
 ```
 
-Now the example is shorter, but it is still not clear what the intend is. You can do even better than the above. The collections in the Toit standard library have `do` functions that iterate the collections and call a block for each element. You can rewrite `print_list` to
+Now the example is shorter, but it is still not clear what the intend is. You
+can do even better than the above. The collections in the Toit standard library
+have `do` functions that iterate the collections and call a block for each
+element. You can rewrite `print_list` to
 
 <!-- RESET CODE -->
 ```
@@ -321,7 +364,9 @@ Now the intend is clear: you are `do`'ing something to the list which correspond
 
 ## Calling functions with named block parameters
 
-Block parameters can also be named. This is indicated in the function signature by enclosing the named parameter in brackets `[ ]` (the same as for other block parameters). For instance, the signature of `Map.remove` is
+Block parameters can also be named. This is indicated in the function signature
+by enclosing the named parameter in brackets `[ ]` (the same as for other block
+parameters). For instance, the signature of `Map.remove` is
 
 ```
 remove key [--if_absent] -> none:
@@ -387,7 +432,11 @@ Here we have formatted the arguments differently, so each of the block arguments
 
 ## Blocks as values
 
-Blocks are values in Toit which is why functions accept them as arguments. A block value is defined as a colon `:` followed by the body of the block which is either a statement on the same line of the block, such as `: null`, or a series of statements on separate lines following the `:` (all statements indented), such as
+Blocks are values in Toit which is why functions accept them as arguments. A
+block value is defined as a colon `:` followed by the body of the block which
+is either a statement on the same line of the block, such as `: null`, or a
+series of statements on separate lines following the `:` (all statements
+indented), such as
 
 ```
 main:
@@ -395,7 +444,8 @@ main:
   print "line"
 ```
 
-In all the examples so far where we have passed blocks as arguments to function, we were really defining the block value in place.
+In all the examples so far where we have passed blocks as arguments to
+function, we were really defining the block value in place.
 Because blocks are values, they can be stored in local variables, just like other values. For example
 
 ```
@@ -404,9 +454,12 @@ main:
   10.repeat block_variable
 ```
 
-Syntactically, it looks a bit cryptic when blocks are stored in local variables. However, the main purpose of blocks is to pass snippets of code to functions.
+Syntactically, it looks a bit cryptic when blocks are stored in local
+variables. However, the main purpose of blocks is to pass snippets of code to
+functions.
 
-Blocks aren't just "normal" functions as in other programming languages. They are much more efficient, but also come with some restrictions.
+Blocks aren't just "normal" functions as in other programming languages. They
+are much more efficient, but also come with some restrictions.
 
 ### Restrictions
 
@@ -422,7 +475,9 @@ Blocks are stack allocated, which is what makes them so efficient, but it also l
 
 ## Defining functions that take block arguments
 
-You can define your own functions that accept block arguments. You have already seen what the function signature should look like: block arguments must be enclosed by brackets `[ ]`.
+You can define your own functions that accept block arguments. You have already
+seen what the function signature should look like: block arguments must be
+enclosed by brackets `[ ]`.
 
 In order to execute a block, you simply call `call` on it. For example, this is how `int.repeat` is implemented:
 

--- a/docs/language/booleans.mdx
+++ b/docs/language/booleans.mdx
@@ -6,7 +6,10 @@ order: 8
 
 In Toit, the boolean type is `bool` and its two values are written `true` and `false`.
 
-Whenever built-in constructs need to evaluate a condition (for example in an `if` or a `while`), then Toit first "boolifies" the given value. The values `false` and `null` are treated like `false` and every other value is converted to `true`.
+Whenever built-in constructs need to evaluate a condition (for example in an
+`if` or a `while`), then Toit first "boolifies" the given value. The values
+`false` and `null` are treated like `false` and every other value is converted
+to `true`.
 So in a condition context, `null` is falsy and other non-booleans are truthy.
 
 ```

--- a/docs/language/definitions.mdx
+++ b/docs/language/definitions.mdx
@@ -39,9 +39,11 @@ Within a class, the following items are available: constructors, statics, factor
 - **Static functions and fields**: Static functions and fields are tied to the class rather than individual objects.
   Inside a class, static fields and functions are marked with the keyword `static`. Constructors and factories are implicitly static.
 
-Static fields are often constants - which can be inferred from their capitalized names, and whether they are final (defined with `::=`).
+Static fields are often constants - which can be inferred from their
+capitalized names, and whether they are final (defined with `::=`).
 
-Inside a class, you can refer to static entries directly. Outside the class, static entries must be prefixed with the class name.
+Inside a class, you can refer to static entries directly. Outside the class,
+static entries must be prefixed with the class name.
 
 ```
 class A:
@@ -183,13 +185,17 @@ class Foo:
 
 The type name corresponds to the class or interface name of all accepted values.
 In addition, Toit has `any` (for every possible type) and `none` (when no value is accepted).
-For example, in the following example `rename from/any to/any -> any` , the function `rename` takes 2 arguments: `foo` of type `any` and `to` of type `any`.
-`any` is a special type meaning “any” type. It means that the code really works for any input type or that the type-info is missing.
+For example, in the following example `rename from/any to/any -> any` , the
+function `rename` takes 2 arguments: `foo` of type `any` and `to` of type
+`any`.
+`any` is a special type meaning “any” type. It means that the code really works
+for any input type or that the type-info is missing.
 
 The `->` indicates the return type of the function, so `foo -> bar` means that the function `foo` returns `bar`.
 The `rename` function in the example `rename from/any to/any -> any` returns `any`.
 
-In the following example the parameter `param`, the local `my_var`, and the global `glob` are all typed in the following example:
+In the following example the parameter `param`, the local `my_var`, and the
+global `glob` are all typed in the following example:
 
 ```
 foo param/int:  // The parameter 'param' must be of type int.
@@ -203,12 +209,14 @@ The type of variable is enforced by the Virtual Machine.
 Every time a value is stored in the variable, the VM checks that the type is correct.
 If it isn't, a runtime [exception](../exceptions) is thrown.
 
-Types are also very helpful during development: the IDE can use the typing information to provide code completion, or warnings when types don't match.
+Types are also very helpful during development: the IDE can use the typing
+information to provide code completion, or warnings when types don't match.
 
 ### Return types
 
 Functions can also declare their return type by writing `->` followed by the return type.
-The `-> type` can be anywhere in the signature, but it's convention to put it at the end of the line that declares the name of a function:
+The `-> type` can be anywhere in the signature, but it's convention to put it
+at the end of the line that declares the name of a function:
 
 <!-- RESET CODE -->
 ```
@@ -230,13 +238,23 @@ gee with/string  -> float  // Returns a float.
 
 ### None
 
-The return type `none` is never needed, as Toit can see whether a method returns something or not. It can, however, help readability of code, and prevent developers from accidentally returning a value.
+The return type `none` is never needed, as Toit can see whether a method
+returns something or not. It can, however, help readability of code, and
+prevent developers from accidentally returning a value.
 
 ### When to Write Types?
 
-In a correct program types don't have any effect. As such they are most important during the development process. Similar to comments, there isn't always a clear-cut rule on when to write code. Different teams don't always agree on the "best" amount of types.
+In a correct program types don't have any effect. As such they are most
+important during the development process. Similar to comments, there isn't
+always a clear-cut rule on when to write code. Different teams don't always
+agree on the "best" amount of types.
 
-We recommend to write types for fields, and in function signatures (parameters and return type). This dramatically improves the development experience as the IDE can use those types to suggest code completions. This is especially true for functions and variables that are intended to be used by different developers. As a general guideline: more users of your code implies you need more types.
+We recommend to write types for fields, and in function signatures (parameters
+and return type). This dramatically improves the development experience as the
+IDE can use those types to suggest code completions. This is especially true
+for functions and variables that are intended to be used by different
+developers. As a general guideline: more users of your code implies you need
+more types.
 
 Local variables often don't need explicit types as the IDE can often figure out the type of local variables.
 If the IDE can't infer the type it is a judgment call whether the type is warranted or not.

--- a/docs/language/exceptions.mdx
+++ b/docs/language/exceptions.mdx
@@ -32,7 +32,11 @@ main:
 
 ## Throw
 
-The `throw` keyword in Toit is used to explicitly throw an exception from a method or any block of code. Any object can be thrown. Currently the core libraries often throw strings containing error messages. Although it looks like a keyword, `throw` is implemented as a function that takes a value to be thrown.
+The `throw` keyword in Toit is used to explicitly throw an exception from a
+method or any block of code. Any object can be thrown. Currently the core
+libraries often throw strings containing error messages. Although it looks like
+a keyword, `throw` is implemented as a function that takes a value to be
+thrown.
 
 ## Catch
 
@@ -42,9 +46,17 @@ Catch will return the thrown object, or `null` if no object was thrown.
 
 Catch takes two optional arguments
 
-- The `--trace` argument is a boolean or a block that evaluates to a boolean. It controls whether the caught exception is reported in the console. By default the exception is not reported. The `trace` block is passed an argument that is the thrown object.
+- The `--trace` argument is a boolean or a block that evaluates to a boolean.
+It controls whether the caught exception is reported in the console. By default
+the exception is not reported. The `trace` block is passed an argument that is
+the thrown object.
 
-- The `--unwind` argument takes a boolean or a block that evaluates to a boolean. It determines whether the execution stack continues to unwind after the catch. By default `unwind` is `false`. If the block evaluates to `true` then the exception will continue to unwind the call stack as if the catch were not present. The `unwind` block is passed the thrown object as an argument, which it can use to determine whether to unwind.
+- The `--unwind` argument takes a boolean or a block that evaluates to a
+boolean. It determines whether the execution stack continues to unwind after
+the catch. By default `unwind` is `false`. If the block evaluates to `true`
+then the exception will continue to unwind the call stack as if the catch were
+not present. The `unwind` block is passed the thrown object as an argument,
+which it can use to determine whether to unwind.
 
 ```
 my_function:

--- a/docs/language/language.mdx
+++ b/docs/language/language.mdx
@@ -4,7 +4,10 @@ order: 0
 
 # Toit language basics
 
-This quick-start guide is inspired by [Ruby in Twenty Minutes](https://www.ruby-lang.org/en/documentation/quickstart/). It makes the assumption that you already have [Toit installed](../../installation/toitcli) on your machine.
+This quick-start guide is inspired by [Ruby in Twenty
+Minutes](https://www.ruby-lang.org/en/documentation/quickstart/). It makes the
+assumption that you already have [Toit installed](../../installation/toitcli)
+on your machine.
 
 Toit is an [object-oriented](../objects-constructors-inheritance-interfaces)
 programming language for the internet of things. The Toit language has the following desirable properties:
@@ -18,7 +21,9 @@ Now, let's get started with some programming!
 
 ## Hello, World
 
-A local installation of Toit comes with support for running small programs directly from the command line. If you put the following code in a file called `hello.toit`
+A local installation of Toit comes with support for running small programs
+directly from the command line. If you put the following code in a file called
+`hello.toit`
 
 ```
 main:
@@ -32,9 +37,17 @@ $ toit execute hello.toit
 Hello World!
 ```
 
-What just happened? The `toit` command line tool read your source code (`hello.toit`) and started running it from the `main` method that you defined. The `main` method consists of all the indented statements just below the method declaration line `main:`. Toit is indentation-based like Python, so the spaces you add to your programs are significant.
+What just happened? The `toit` command line tool read your source code
+(`hello.toit`) and started running it from the `main` method that you defined.
+The `main` method consists of all the indented statements just below the method
+declaration line `main:`. Toit is indentation-based like Python, so the spaces
+you add to your programs are significant.
 
-Once the program ran, it printed `Hello World!` in your terminal. This is because the only statement in `hello.toit` is a method call, where you invoke the `print` method with a single argument, which is the [string](../strings) to be printed (in this case to the terminal). If you wanted to output more than one line from your program, you could update it to:
+Once the program ran, it printed `Hello World!` in your terminal. This is
+because the only statement in `hello.toit` is a method call, where you invoke
+the `print` method with a single argument, which is the [string](../strings) to
+be printed (in this case to the terminal). If you wanted to output more than
+one line from your program, you could update it to:
 
 ```
 main:
@@ -67,7 +80,8 @@ main:
   hi
 ```
 
-Calling a function in Toit is as simple as mentioning its name. If the function doesn’t take arguments that’s all you need.
+Calling a function in Toit is as simple as mentioning its name. If the function
+doesn’t take arguments that’s all you need.
 
 What if we want to say hello to one person, and not the whole world? Just redefine hi to take a name as an argument.
 
@@ -106,13 +120,20 @@ hi name="World":
   print "Hello, $name.trim!"
 ```
 
-This way, we call the `trim` function on the `name` string before we insert it into the outer string. If we call `hi "   Lars  "` we still get the familiar greeting `Hello Lars!` and not `Hello   Lars  !`. You can add parentheses around the `name.trim` expression in the string to make it clearer which parts belong to the outer string:
+This way, we call the `trim` function on the `name` string before we insert it
+into the outer string. If we call `hi "   Lars  "` we still get the familiar
+greeting `Hello Lars!` and not `Hello   Lars  !`. You can add parentheses
+around the `name.trim` expression in the string to make it clearer which parts
+belong to the outer string:
 
 ```
   print "Hello, $(name.trim)!"
 ```
 
-Maybe you already spotted that we went ahead and added one other trick to the code above? We added a default value for the `name` parameter, so if the name isn’t supplied when you call `hi`, we use the default name "World". Now we can try:
+Maybe you already spotted that we went ahead and added one other trick to the
+code above? We added a default value for the `name` parameter, so if the name
+isn’t supplied when you call `hi`, we use the default name "World". Now we can
+try:
 
 ```
 main:
@@ -130,7 +151,9 @@ Hello Kasper!
 
 ## Evolving into a greeter
 
-What if we want a real greeter around, one that remembers your name and welcomes you and treats you with respect. You might want to use an object for that. Let’s create a `Greeter` class:
+What if we want a real greeter around, one that remembers your name and
+welcomes you and treats you with respect. You might want to use an object for
+that. Let’s create a `Greeter` class:
 
 ```
 class Greeter:
@@ -164,7 +187,11 @@ parameter actually tells us that the name is immediately stored as a field on
 
 The field parameter `.name` still has a default value, so if we don’t pass a name, the `Greeter` will greet the world.
 
-The `say_hi` and `say_bye` methods are introduced on the next two lines. The methods both have a single statement in them, so we can keep them on one line each. The `say_hi` and `say_bye` method both use the `name` field from the object they are called on. You can refer to fields in the class of a method simply by mentioning them (`name`).
+The `say_hi` and `say_bye` methods are introduced on the next two lines. The
+methods both have a single statement in them, so we can keep them on one line
+each. The `say_hi` and `say_bye` method both use the `name` field from the
+object they are called on. You can refer to fields in the class of a method
+simply by mentioning them (`name`).
 
 ## Creating a greeter object
 
@@ -177,7 +204,9 @@ main:
   greeter.say_bye
 ```
 
-We create an object simply by mentioning the constructor, `Greeter`. The greeter object remembers the name and uses it for the two separate greetings. If we run this, we get the following output:
+We create an object simply by mentioning the constructor, `Greeter`. The
+greeter object remembers the name and uses it for the two separate greetings.
+If we run this, we get the following output:
 
 ```txt
 $ toit execute hello.toit
@@ -193,11 +222,15 @@ main:
   print "How are you $(greeter.name)?"
 ```
 
-This would show `How are you  Helena ?`. Almost neat, right? Unfortunately, the name isn’t trimmed like we expected. Let’s fix that!
+This would show `How are you  Helena ?`. Almost neat, right? Unfortunately, the
+name isn’t trimmed like we expected. Let’s fix that!
 
 ## Fields and methods
 
-As you have just seen, a field on an object introduces a method with the same name. If you wanted to hide a field from the outside world, you could make it private. By convention, methods and fields that end with an underscore (`_`) are private and not supposed to be touched from the outside:
+As you have just seen, a field on an object introduces a method with the same
+name. If you wanted to hide a field from the outside world, you could make it
+private. By convention, methods and fields that end with an underscore (`_`)
+are private and not supposed to be touched from the outside:
 
 <!-- RESET CODE -->
 ```
@@ -206,7 +239,9 @@ class Greeter:
   constructor .name_="World":
 ```
 
-This removes the `name` method from greeters, but if we really want to allow accessing the name from the outside, we could reintroduce a getter with the same meaning as before.
+This removes the `name` method from greeters, but if we really want to allow
+accessing the name from the outside, we could reintroduce a getter with the
+same meaning as before.
 
 <!-- RESET CODE -->
 ```
@@ -220,14 +255,16 @@ class Greeter:
   say_bye: print "Bye $name_.trim, come back soon."
 ```
 
-Here we use the new keyword `return` to specify the value a method returns. We could make it slightly more interesting and trim it in the process:
+Here we use the new keyword `return` to specify the value a method returns. We
+could make it slightly more interesting and trim it in the process:
 
 <!-- SKIP CODE -->
 ```
   name: return name_.trim
 ```
 
-In this way, access to the name from the outside also gets the trimming and we can avoid having to manually call `trim` when getting the name:
+In this way, access to the name from the outside also gets the trimming and we
+can avoid having to manually call `trim` when getting the name:
 
 <!-- RESET CODE -->
 ```
@@ -255,7 +292,10 @@ member variables in classes.
 
 ## Greetings everyone!
 
-This greeter isn’t all that interesting though, it can only deal with one person at a time. What if we had some kind of MegaGreeter that could either greet the world, one person, or a whole list of people? Let’s try to build that. We will start with a class definition:
+This greeter isn’t all that interesting though, it can only deal with one
+person at a time. What if we had some kind of MegaGreeter that could either
+greet the world, one person, or a whole list of people? Let’s try to build
+that. We will start with a class definition:
 
 ```
 class MegaGreeter:
@@ -265,7 +305,13 @@ class MegaGreeter:
     names.add name
 ```
 
-So MegaGreeter objects have a [list](../listsetmap) of `names`. The `names` field is initialized to the empty list (`[]`). The body of the `MegaGreeter` constructor adds the given `name` argument to the end of the list of names. Notice that this is different than using a `.name` parameter that automatically assigns to the field called `name`. Mega greeters don't have a single name and no `name` field, so here the `name` is just an ordinary parameter that we can use in the body of the constructor. All in all, this code:
+So MegaGreeter objects have a [list](../listsetmap) of `names`. The `names`
+field is initialized to the empty list (`[]`). The body of the `MegaGreeter`
+constructor adds the given `name` argument to the end of the list of names.
+Notice that this is different than using a `.name` parameter that automatically
+assigns to the field called `name`. Mega greeters don't have a single name and
+no `name` field, so here the `name` is just an ordinary parameter that we can
+use in the body of the constructor. All in all, this code:
 
 ```
 main:
@@ -327,7 +373,10 @@ Let’s dive into the new constructs in the next sections.
 
 ## Comments and indentation
 
-Not everything in your source files is meant to be run by the Toit compiler. Sometimes, it is nice just to add comments that explain interesting things related to your code. In the example in the last section, there were a few single line comments:
+Not everything in your source files is meant to be run by the Toit compiler.
+Sometimes, it is nice just to add comments that explain interesting things
+related to your code. In the example in the last section, there were a few
+single line comments:
 
 <!-- SKIP CODE -->
 ```
@@ -337,7 +386,9 @@ class MegaGreeter:
 
 Such comments start with `//` and tell the system to ignore the rest of the line.
 
-You have already seen the use of indentation to give hierarchical structure to your code. The general structure is that after a `:` you can have a single construct if it fits on one line:
+You have already seen the use of indentation to give hierarchical structure to
+your code. The general structure is that after a `:` you can have a single
+construct if it fits on one line:
 
 ```
 class SimpleGreeter:
@@ -345,7 +396,8 @@ class SimpleGreeter:
   say_hi: print "Hi!"  // Method all on one line.
 ```
 
-or you can add a newline after the `:` and let the following lines that are indented relative to the outer construct be a sequence of inner constructs:
+or you can add a newline after the `:` and let the following lines that are
+indented relative to the outer construct be a sequence of inner constructs:
 
 ```
   names := []
@@ -356,9 +408,12 @@ or you can add a newline after the `:` and let the following lines that are inde
     print "Bye $everyone, come back soon."
 ```
 
-For methods, we often refer to the inner constructs as the statements of a method or the body of a method. The preferred indentation for inner constructs is two spaces.
+For methods, we often refer to the inner constructs as the statements of a
+method or the body of a method. The preferred indentation for inner constructs
+is two spaces.
 
-For a class, everything that is indented under the class declaration line belongs to the class. We call such things class members:
+For a class, everything that is indented under the class declaration line
+belongs to the class. We call such things class members:
 
 <!-- RESET CODE -->
 ```
@@ -387,7 +442,11 @@ It is common to refer to such nested structure as _block structure_.
 
 ## Iterating over lists
 
-Let’s return to the `MegaGreeter` example and take a look at another place where constructs are block structured. In the `say_hi` method, we want to call `print` for every single name in the `names` [list](../listsetmap). We can do this by calling `names.do` and provide the list of statements we want to run for each element using block structure:
+Let’s return to the `MegaGreeter` example and take a look at another place
+where constructs are block structured. In the `say_hi` method, we want to call
+`print` for every single name in the `names` [list](../listsetmap). We can do
+this by calling `names.do` and provide the list of statements we want to run
+for each element using block structure:
 
 <!-- RESET CODE -->
 <!-- HIDDEN CODE class MegaGreeter: -->
@@ -419,7 +478,11 @@ main:
   list.do: print "Element = $it"
 ```
 
-One of the methods on lists that is very useful when constructing strings is `join`. It produces a string from a list of strings by joining the parts and adding a separator between them. We use this in the `MegaGreeter` example to produce a single comma-separated list of names for the single line output of `say_bye`:
+One of the methods on lists that is very useful when constructing strings is
+`join`. It produces a string from a list of strings by joining the parts and
+adding a separator between them. We use this in the `MegaGreeter` example to
+produce a single comma-separated list of names for the single line output of
+`say_bye`:
 
 <!-- RESET CODE -->
 <!-- HIDDEN CODE class MegaGreeter: -->
@@ -456,7 +519,8 @@ Kaixo, World!
 Kaixo, Lars!
 Kaixo, Kasper!
 ```
-However, at the calling site it may not be clear what the argument "Kaixo" is for. We can make it clearer with a named argument:
+However, at the calling site it may not be clear what the argument "Kaixo" is
+for. We can make it clearer with a named argument:
 
 <!-- RESET CODE -->
 <!-- HIDDEN CODE class MegaGreeter: -->
@@ -500,11 +564,23 @@ main:
   print "The 10th Fibonacci number is $(fib 10)"
 ```
 
-This defines a top-level function called `fib` that is not a member of any class.  (We already saw `main`, which is a top level function with a special name.)
+This defines a top-level function called `fib` that is not a member of any
+class.  (We already saw `main`, which is a top level function with a special
+name.)
 
-The `fib` function is recursive, calling itself, and also makes use of a few new features.  The [if-statement](../loops#if-statements) is well known from other languages.  In Toit it works by taking an expression and conditionally evaluating a block.  Like other blocks we could have used indentation to group multiple lines.
+The `fib` function is recursive, calling itself, and also makes use of a few
+new features.  The [if-statement](../loops#if-statements) is well known from
+other languages.  In Toit it works by taking an expression and conditionally
+evaluating a block.  Like other blocks we could have used indentation to group
+multiple lines.
 
-Toit also has the usual array of infix operators, `+`, `-`, `*`, `/`, `%` etc.  and the relational operators `<`, `<=`, `>`, `>=`, `==` and `!=`.  The operators have higher [precedence](../syntax#precedence) than function arguments, so we had to group the calls in parentheses to get the desired behavior.  The high precedence is what makes the arguments for the recursive invocation of `fib` work.  We could have spaced it more conventionally and got the same effect:
+Toit also has the usual array of infix operators, `+`, `-`, `*`, `/`, `%` etc.
+and the relational operators `<`, `<=`, `>`, `>=`, `==` and `!=`.  The
+operators have higher [precedence](../syntax#precedence) than function
+arguments, so we had to group the calls in parentheses to get the desired
+behavior.  The high precedence is what makes the arguments for the recursive
+invocation of `fib` work.  We could have spaced it more conventionally and got
+the same effect:
 
 <!-- RESET CODE -->
 ```
@@ -515,7 +591,8 @@ fib n:
 
 ## Loops
 
-This is a terribly slow way to calculate a Fibonacci number though, and we could do it with a simple [loop](../loops#loops):
+This is a terribly slow way to calculate a Fibonacci number though, and we
+could do it with a simple [loop](../loops#loops):
 
 ```
 fib2 n:
@@ -528,7 +605,9 @@ fib2 n:
   return s1
 ```
 
-Here we are using the `repeat` method on numbers, which runs a block a given number of times.  Like for the `do` method, there's an automatic variable, `it` that gives the iteration number:
+Here we are using the `repeat` method on numbers, which runs a block a given
+number of times.  Like for the `do` method, there's an automatic variable, `it`
+that gives the iteration number:
 
 ```
 // Prints the numbers from 0 to n (exclusive).
@@ -536,7 +615,9 @@ print_n_numbers n:
   n.repeat: print it
 ```
 
-The `repeat` method is simple and efficient, but sometimes we need something more flexible, and for that we have the well-known `while` and `for` statements:
+The `repeat` method is simple and efficient, but sometimes we need something
+more flexible, and for that we have the well-known `while` and `for`
+statements:
 
 ```
 // Prints the odd numbers less than n.
@@ -578,7 +659,11 @@ main:
   greeter.say_hi
 ```
 
-Here we use a [hash map](../listsetmap) to store the appropriate title for each name.  The empty map is given by `{:}` and we use `[]` to access the values for each key.  The empty set is `{}` and we already met the empty list, `[]`.  The lookup syntax `[]` also works on lists, so instead of the 'do' method we could have used:
+Here we use a [hash map](../listsetmap) to store the appropriate title for each
+name.  The empty map is given by `{:}` and we use `[]` to access the values for
+each key.  The empty set is `{}` and we already met the empty list, `[]`.  The
+lookup syntax `[]` also works on lists, so instead of the 'do' method we could
+have used:
 
 <!-- RESET CODE -->
 <!-- HIDDEN CODE class MegaGreeter: -->
@@ -604,7 +689,9 @@ main:
     print it
 ```
 
-Syntactically they look like they are built in to the language like `if` and `for`, but they are actually perfectly normal methods on the List and Integer classes:
+Syntactically they look like they are built in to the language like `if` and
+`for`, but they are actually perfectly normal methods on the List and Integer
+classes:
 
 <!-- SKIP CODE -->
 ```
@@ -620,7 +707,12 @@ class Integer:
       block.call i
 ```
 
-They are making use of a feature called [blocks](../blocks).  These are snippets of code that can be passed down the stack as arguments to methods and functions.  At the call site we precede the block with a colon, '`:`', and at the function definition we surround the parameter name with square brackets, '`[]`'.  Often, there is one block parameter, it is in the final position and it is called `block`.
+They are making use of a feature called [blocks](../blocks).  These are
+snippets of code that can be passed down the stack as arguments to methods and
+functions.  At the call site we precede the block with a colon, '`:`', and at
+the function definition we surround the parameter name with square brackets,
+'`[]`'.  Often, there is one block parameter, it is in the final position and
+it is called `block`.
 
 ## Blocks that return a value
 
@@ -634,11 +726,17 @@ short_words words:
     it.size <= 5
 ```
 
-The `filter` method calls the block, `it.size <= 5` for each element in the original list, and returns a new list containing only the short words.
+The `filter` method calls the block, `it.size <= 5` for each element in the
+original list, and returns a new list containing only the short words.
 
-Note that there is no `return` statement in the block.  A block will return the value of the last statement to the place where it was invoked with `block.call`.  In this case there is only one statement, which is the [boolean](../booleans) expression `it.size <= 5`.
+Note that there is no `return` statement in the block.  A block will return the
+value of the last statement to the place where it was invoked with
+`block.call`.  In this case there is only one statement, which is the
+[boolean](../booleans) expression `it.size <= 5`.
 
-If you use the `return` keyword in a block then it returns from the syntactic function or method in which it is written.  Usually this will behave as you would expect:
+If you use the `return` keyword in a block then it returns from the syntactic
+function or method in which it is written.  Usually this will behave as you
+would expect:
 
 ```
 wheres_walter list:
@@ -651,4 +749,7 @@ main:
   print (wheres_walter ["Ib Michael", "Walter White", "Marie Curie"])
 ```
 
-The `return` keyword is inside a block that is passed to the `do` method.  When the name that starts with `"Walter "` is found we immediately return the full name from the `wheres_walter` function without continuing to iterate over the list.
+The `return` keyword is inside a block that is passed to the `do` method.  When
+the name that starts with `"Walter "` is found we immediately return the full
+name from the `wheres_walter` function without continuing to iterate over the
+list.

--- a/docs/language/listsetmap.mdx
+++ b/docs/language/listsetmap.mdx
@@ -4,22 +4,32 @@ order: 6
 
 # List, Set and Map in Toit
 
-The following classes are included in the core SDK as part of the [collections.toit module](https://libs.toit.io/core/collections/library-summary):
+The following classes are included in the core SDK as part of the
+[collections.toit module](https://libs.toit.io/core/collections/library-summary):
 
-`List` provides an ordered and indexed collection which may contain duplicates. This is roughly analogous to extendable arrays in other languages.
+`List` provides an ordered and indexed collection which may contain duplicates.
+This is roughly analogous to extendable arrays in other languages.
 
-`Set` provides a collection of unique objects. When iterating over a `Set`, the objects are processed in insertion order.
+`Set` provides a collection of unique objects. When iterating over a `Set`, the
+objects are processed in insertion order.
 
-`Map` provides a data structure mapping keys to values. Like `Set`, iteration is in insertion order. Overwriting the value associated with a key does not change the order of the key-value pair.
+`Map` provides a data structure mapping keys to values. Like `Set`, iteration
+is in insertion order. Overwriting the value associated with a key does not
+change the order of the key-value pair.
 
-The `Set` and `Map` implementations use hashing to do their operations in constant speed. As a consequence their keys must have a `hash_code` member.
+The `Set` and `Map` implementations use hashing to do their operations in
+constant speed. As a consequence their keys must have a `hash_code` member.
 
 There are two concrete implementations of `Set` and `Map`:
-`Set`/`Map` use the overwritable `==` operator to determine whether two keys are equal, whereas `IdentitySet`/`IdentityMap` use `identical`.
+`Set`/`Map` use the overwritable `==` operator to determine whether two keys
+are equal, whereas `IdentitySet`/`IdentityMap` use `identical`.
 
 See some examples of use of `List` and `Map` in the section [Toit blocks](../blocks).
 
-See also the documentation for the [List](https://libs.toit.io/core/collections/class-List), [Set](https://libs.toit.io/core/collections/class-Set), and [Map](https://libs.toit.io/core/collections/class-Map) classes.
+See also the documentation for the
+[List](https://libs.toit.io/core/collections/class-List),
+[Set](https://libs.toit.io/core/collections/class-Set), and
+[Map](https://libs.toit.io/core/collections/class-Map) classes.
 
 The [string](../strings) and
 [ByteArray](https://libs.toit.io/core/collections/class-ByteArray) classes are
@@ -189,7 +199,8 @@ if-statement. The `any` method is often called `some` in functional languages.)
 Both of these examples made use of the
 [automatic block argument, `it`](../blocks#block-arguments).
 
-Similarly, Toit collections have the [`every`](<https://libs.toit.io/core/collections/class-Collection#every(1%2C1%2C0%2C)>)
+Similarly, Toit collections have the
+[`every`](<https://libs.toit.io/core/collections/class-Collection#every(1%2C1%2C0%2C)>)
 method known from functional languages:
 
 ```
@@ -307,5 +318,6 @@ main:
   print my_list[0]
 ```
 
-The block takes two arguments, which are here called `a` and `b` and should return (implicitly) a value that can be negative, zero, or positive.
+The block takes two arguments, which are here called `a` and `b` and should
+return (implicitly) a value that can be negative, zero, or positive.
 Note that `b - a` sorts in descending order.

--- a/docs/language/loops.mdx
+++ b/docs/language/loops.mdx
@@ -147,7 +147,10 @@ main:
     sum += i
 ```
 
-The `for` and `while` loops are control structures built into the language, which support `break` and `continue`. On the other hand, `repeat` and `do` are methods that take blocks. Here you have to add the method name (do or repeat) to the continue statement, to indicate which loop you wish to continue.
+The `for` and `while` loops are control structures built into the language,
+which support `break` and `continue`. On the other hand, `repeat` and `do` are
+methods that take blocks. Here you have to add the method name (do or repeat)
+to the continue statement, to indicate which loop you wish to continue.
 
 ```
 main:
@@ -173,4 +176,5 @@ my_function collection:
   return null
 ```
 
-If this is not possible, and you need an actual `break` statement, the `do` or `repeat` can be rewritten with a `for` loop.
+If this is not possible, and you need an actual `break` statement, the `do` or
+`repeat` can be rewritten with a `for` loop.

--- a/docs/language/math.mdx
+++ b/docs/language/math.mdx
@@ -4,7 +4,10 @@ order: 9
 
 # Mathematics in Toit
 
-Find mathematical algorithms in the [math module](https://libs.toit.io/math/library-summary), and the numbers available in the [numbers module](https://libs.toit.io/core/numbers/library-summary) of the core library.
+Find mathematical algorithms in the
+[math module](https://libs.toit.io/math/library-summary), and the numbers available
+in the [numbers module](https://libs.toit.io/core/numbers/library-summary) of
+the core library.
 
 ## Numbers
 
@@ -12,21 +15,31 @@ Toit [numbers](https://libs.toit.io/core/numbers/library-summary) support intege
 
 ### Integers and floats
 
-[Integers](https://libs.toit.io/core/numbers/class-int) are whole numbers such as -1, 0, 1, 2, 3, .. and they have type `int`.
-[Floats](https://libs.toit.io/core/numbers/class-float) are numbers with a decimal point. Floats are contagious, meaning that any binary operation involving a float forces the other operand to be converted to a float before doing the operation (thus yielding a float as result).
+[Integers](https://libs.toit.io/core/numbers/class-int) are whole numbers such
+as -1, 0, 1, 2, 3, .. and they have type `int`.
+[Floats](https://libs.toit.io/core/numbers/class-float) are numbers with a
+decimal point. Floats are contagious, meaning that any binary operation
+involving a float forces the other operand to be converted to a float before
+doing the operation (thus yielding a float as result).
 
 Integers are 64-bit signed integers.
-Floats are of size 64-bit, following the [IEEE 754-1985 double format](https://en.wikipedia.org/wiki/Double-precision_floating-point_format).
+Floats are of size 64-bit, following the
+[IEEE 754-1985 double format](https://en.wikipedia.org/wiki/Double-precision_floating-point_format).
 
 To make large numbers more readable, digits are often grouped using underscores.
 When storing these values and when displaying them on screen, Toit just ignores the underscores.
 
 Underscores work for both [integers](https://libs.toit.io/core/numbers/class-LargeInteger) and floats.
 
-You can use the [mathematics operators](https://libs.toit.io/core/numbers/class-num) such as `+`, `-`, `*`, and `/` to form expressions that include numbers.
-The [int class](https://libs.toit.io/core/numbers/class-int) has additional operations (like bit-shifting) that are not supported by the floating point numbers.
+You can use the [mathematics
+operators](https://libs.toit.io/core/numbers/class-num) such as `+`, `-`, `*`,
+and `/` to form expressions that include numbers.
+The [int class](https://libs.toit.io/core/numbers/class-int) has additional
+operations (like bit-shifting) that are not supported by the floating point
+numbers.
 
-Additional mathematical constants and functions are available in the [math module](https://libs.toit.io/math/library-summary).
+Additional mathematical constants and functions are available in the
+[math module](https://libs.toit.io/math/library-summary).
 
 ```
 import math
@@ -37,7 +50,8 @@ main:
 
 ## Randomization
 
-`random` is a function included in the [core library](https://libs.toit.io/core/utils/library-summary#random(0%2C0%2C0%2C))
+`random` is a function included in the
+[core library](https://libs.toit.io/core/utils/library-summary#random(0%2C0%2C0%2C))
 
 `random 10` gives you a random number between 0 and 10 (10 exclusive).
 

--- a/docs/language/syntax.mdx
+++ b/docs/language/syntax.mdx
@@ -4,7 +4,9 @@ order: 3
 
 # Toit syntax fundamentals
 
-This document describes the basics of the Toit language. To learn about Toit's documentation convention, see the language [documentation convention](../../sdk/toitdoc) section.
+This document describes the basics of the Toit language. To learn about Toit's
+documentation convention, see the language [documentation
+convention](../../sdk/toitdoc) section.
 
 ## Whitespace and indentation
 
@@ -30,6 +32,10 @@ colon-equals.  We assigned a new value to the existing variable,
 giving it a value, you can use a question mark: `:= ?`.
 
 ```
+  x := 0
+  if (random 2) == 0:
+    x = 42
+
   y := ?
   if (random 2) == 0:
     y = 1
@@ -79,9 +85,14 @@ static      true           try
 while       or     and     not
 ```
 
-In addition to these keywords, there are some "pseudo keywords" - like `constructor` - that cannot be used in certain contexts. Trying these pseudo-keywords as globals name will generally give an error message in the IDE.
+In addition to these keywords, there are some "pseudo keywords" - like
+`constructor` - that cannot be used in certain contexts. Trying these
+pseudo-keywords as globals name will generally give an error message in the
+IDE.
 
-Another example of pseudo-keyword is `operator` that is allowed as a local but cannot be the name of a function. Similarly, `string` can be used like a normal global but would shadow the `string` type.
+Another example of pseudo-keyword is `operator` that is allowed as a local but
+cannot be the name of a function. Similarly, `string` can be used like a normal
+global but would shadow the `string` type.
 
 ## String and character literals
 
@@ -142,9 +153,11 @@ A final global that isn't a constant could be something that is mutable itself, 
 ```
 some_global ::= []
 ```
-In this case the global is initialized with an empty list. The content of the list can change, but it will always be the same list.
+In this case the global is initialized with an empty list. The content of the
+list can change, but it will always be the same list.
 
-When you name a global, you should adhere to rules defined earlier about [identifiers](../syntax#identifiers-and-keywords).
+When you name a global, you should adhere to rules defined earlier about
+[identifiers](../syntax#identifiers-and-keywords).
 
 Global variables (and [static class
 variables](../definitions)) are initialized when


### PR DESCRIPTION
These long lines are hard to read in a wide window
and make it hard to read diffs, because a single
change in a long line causes the whole line to be
marked different.

This change has no content changes, only formatting.

There is no requirement going forward to keep lines
equal in length when editing.  This would also cause
diffs to be larger than required.