### PR TITLE
Don't mention the 2 minutes time out on `toit run` and in Code tab

### DIFF
--- a/docs/platform/console/devicemanagement.mdx
+++ b/docs/platform/console/devicemanagement.mdx
@@ -64,12 +64,7 @@ App installation status is color-coded to the left hand side of each row in the 
 ## Code
 
 The code tab includes a terminal window where you can write a Toit program. Click on **Run on device** to run the program on the device.
-
-<Note>
-
-A program will automatically stop running after approximately 2 minutes, but you can also use the **Stop** button.
-
-</Note>
+There is a list of Toit example code snippets that you can try out on your ESP32 or simulator.
 
 ## Configuration
 

--- a/docs/platform/deploy/runordeploy.mdx
+++ b/docs/platform/deploy/runordeploy.mdx
@@ -8,7 +8,7 @@ With Toit, there are two ways to execute code on a device:
 
 - **Running programs**
 
-  Running a program means that the Toit code runs once on an online device. When the program has terminated, or the program lasts longer than 2 minutes, the program is removed from the device.
+  Running a program means that the Toit code runs once on an online device. When the program has terminated, the program is removed from the device.
 
 - **Deploying applications**
 
@@ -18,7 +18,7 @@ With Toit, there are two ways to execute code on a device:
 
 This option makes it easy to run small snippets of Toit code on a device. The device needs to be online since the installation and execution of the code happens synchronously such that you get feedback right away.
 
-Running a program on a device does not allow the device to go into deep sleep as it needs to remain online for the program to run, even if it is set to make a measurement only once a day. Therefore the `toit run` command is great for running small snippets of code on a device but not built for running actual long-lived applications. For this reason, the Toit cloud will terminate any running program after 2 minutes of execution.
+Running a program on a device does not allow the device to go into deep sleep as it needs to remain online for the program to run, even if it is set to make a measurement only once a day. Therefore the `toit run` command is great for running small snippets of code on a device but not built for running actual long-lived applications.
 
 ## Deploy apps on a device
 


### PR DESCRIPTION
Since it has changed to 30 minutes now. So just remove everything about the time out in the docs.

Fixes: #247