### PR TITLE
Clickable boxes

### DIFF
--- a/docs/getstarted/installation/index.mdx
+++ b/docs/getstarted/installation/index.mdx
@@ -1,4 +1,5 @@
 ---
 order: 3
 title: Installation
+hide: true
 ---

--- a/docs/getstarted/installation/linux.mdx
+++ b/docs/getstarted/installation/linux.mdx
@@ -1,5 +1,6 @@
 ---
 order: 13
+hide: true
 ---
 
 import Extract from "../../_images/extract.png";

--- a/docs/getstarted/installation/macos.mdx
+++ b/docs/getstarted/installation/macos.mdx
@@ -1,5 +1,6 @@
 ---
 order: 12
+hide: true
 ---
 
 # Toit for macOS

--- a/docs/getstarted/installation/windows.mdx
+++ b/docs/getstarted/installation/windows.mdx
@@ -1,5 +1,6 @@
 ---
 order: 11
+hide: true
 ---
 
 # Toit for Windows

--- a/src/components/Boxes.tsx
+++ b/src/components/Boxes.tsx
@@ -3,7 +3,6 @@ import Color from "color";
 import * as React from "react";
 import { ReactNode } from "react";
 import { DocsLink } from "./DocsLink";
-import { FiArrowRight } from "react-icons/fi";
 
 const useStyles = makeStyles((theme) => ({
   boxes: {
@@ -22,11 +21,20 @@ const useStyles = makeStyles((theme) => ({
     "& p:last-child": {
       marginBottom: 0,
     },
+    // Because the a element takes precedent over this class, we need
+    // to use important here. Refactoring this would make it unnecessarily
+    // complicated.
+    textDecoration: "none !important",
+    color: `${Color(theme.palette.text.primary).string()} !important`,
+    transition: "background 200ms ease",
+    "&:hover": {
+      background: `${Color(theme.palette.primary.main).alpha(0.1).string()}`,
+    },
   },
   title: {
     fontWeight: "bold",
     fontSize: "1.3rem",
-    margin: "0 0 0.5rem 0 !important",
+    margin: "0 0 0 0 !important",
   },
   content: {
     flex: 1,
@@ -57,21 +65,16 @@ export function Boxes({ children }: BoxesProps): JSX.Element {
 
 type BoxProps = {
   title?: string;
-  to?: string;
+  to: string;
   children: ReactNode;
 };
 
 export function Box({ title, to, children }: BoxProps): JSX.Element {
   const classes = useStyles();
   return (
-    <div className={classes.box}>
+    <DocsLink href={to} className={classes.box}>
       {title && <h1 className={classes.title}>{title}</h1>}
-      <div className={classes.content}>{children}</div>
-      {to && (
-        <DocsLink className={classes.link} href={to}>
-          Learn more <FiArrowRight />
-        </DocsLink>
-      )}
-    </div>
+      {children && <div className={classes.content}>{children}</div>}
+    </DocsLink>
   );
 }

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -22,7 +22,7 @@ Download and install the Toit development environment to be able to utilize the 
 <Box title="Language guide" to="/language/language">
 
 Take the language tour and learn the Toit programming language tailored for embedded devices.
-Learn how to adapt Toit packages in your code by utilizing the publicly available [Toit package registry](https://pkg.toit.io).
+Learn how to adapt Toit packages in your code by utilizing the publicly available Toit package registry.
 
 </Box>
 <Box title="Tutorials" to="/tutorials">


### PR DESCRIPTION
# WARNING, this PR merges into `installation-restructure`

The whole boxes are now clickable and have a hover effect.

I've also made sure when a box only contains a title, that it's centered in the box and the paddings are uniform.

I've also hidden the installation steps for mac/linux/windows from the main menu

<img width="780" alt="image" src="https://user-images.githubusercontent.com/133277/137925381-24506ff2-23b2-49ce-bcc3-b16c5a4a7979.png">

<img width="1332" alt="image" src="https://user-images.githubusercontent.com/133277/137925440-cb603a76-603d-469c-98d0-5b47c3959db9.png">
