### PR TITLE
Remove the bitmask article from the index.

### DIFF
--- a/docs/menu.yaml
+++ b/docs/menu.yaml
@@ -122,8 +122,6 @@ items:
             path: /peripherals/drivers/qwiic
           - name: How to write a driver
             path: /peripherals/drivers/sparkfun_joystick
-          - name: Bitwise operations
-            path: /peripherals/drivers/bitmask
   - name: Language
     path: /language
     icon: language


### PR DESCRIPTION
This is not at the right level for our target
users.  If they can't do bitops they will never
manage to write a driver even with this documentation.
For those that already understand bitops it is
condescending.