### PR TITLE
Fix ESP Wiki link.

### DIFF
--- a/docs/support/troubleshoot/setuptroubleshoot.mdx
+++ b/docs/support/troubleshoot/setuptroubleshoot.mdx
@@ -12,7 +12,7 @@
 - If provisioning doesn't work, consult the documentation for your ESP32 chip.
 
 - If you have timeout problems when provisioning, some hardware models require you to [hold down BOOT button](https://randomnerdtutorials.com/solved-failed-to-connect-to-esp32-timed-out-waiting-for-packet-header/).
-  Read more info about the bootloader mode [here](https://github.com/espressif/esptool/wiki/ESP32-Boot-Mode-Selection).
+  Read more info about the bootloader mode [here](https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/boot-mode-selection.html).
 
 - If your device wasn't able to connect via WiFi to the Toit cloud during the provisioning, it is not yet claimed. In this state the device is provisioned with the Toit firmware,
   but is not yet added to your Toit project. Follow the steps [here](../claimtroubleshoot) to manually claim the device once it has managed to go


### PR DESCRIPTION
All of Espressif's Wiki was moved into the documentation.

Fixes https://github.com/toitware/public/issues/34.