### PR TITLE
Explain that you might need to specify which device.

### DIFF
--- a/docs/tutorials/pubsub/index.mdx
+++ b/docs/tutorials/pubsub/index.mdx
@@ -51,15 +51,16 @@ Run the subscriber example with the CLI command
 toit run subscribe.toit
 ```
 
-on your default device.
+This runs the `subscribe.toit` program on your default device. If
+you have more than one device and haven't defined a default device
+you can use the `-d` option to specify on which device the program
+should run.
 
 Once the program has started, open another terminal window and run the publisher example with the CLI command
 
 ```shell
 toit run publish.toit
 ```
-
-also on your default device.
 
 The output of both executions on the same device are shown below:
 

--- a/docs/tutorials/starter/index.mdx
+++ b/docs/tutorials/starter/index.mdx
@@ -37,6 +37,10 @@ Save the above Toit program in a file named `time.toit`, and run the command
 toit run time.toit
 ```
 
+This runs the `time.toit` program on your default device. If you have
+more than one device and haven't defined a default device yet, you can
+use the `-d` option to specify on which device the program should run.
+
 The output is printed in the terminal window after program execution.
 
 ```shell

--- a/docs/tutorials/starter/weatherstation.mdx
+++ b/docs/tutorials/starter/weatherstation.mdx
@@ -20,7 +20,7 @@ If you haven't installed the Toit CLI and the Visual Studio Code language extens
 follow this [guide](../../../getstarted/installation) before proceeding with the tutorial.
 
 In order to get data from the sensor we make use of the BME280 driver available as a **package** from
-[pkg.toit.io](https://pkg.toit.io/package/github.com%2Ftoitware%2Fbme280-driver@v1.0.0).
+[pkg.toit.io](https://pkg.toit.io/package/github.com%2Ftoitware%2Fbme280-driver).
 
 Open Visual Studio Code, and create a new file. Paste the following Toit program into the file and save the file as: `weather_station.toit`:
 
@@ -51,9 +51,8 @@ main:
 Then, open a terminal window in VSCode and execute the following commands in order to install the BME280 driver package locally:
 
 ```shell
-toit pkg sync
 toit pkg init
-toit pkg install bme280
+toit pkg install github.com/toitware/bme280-driver
 ```
 
 ## Run Toit program


### PR DESCRIPTION
`toit run` uses the default device, but you might need to use `-d` if
that one isn't defined yet.

Also make the `toit pkg install` use a full URL.