### PR TITLE
Fixing some broken relative links.

### DIFF
--- a/docs/tutorials/misc/c-service.mdx
+++ b/docs/tutorials/misc/c-service.mdx
@@ -21,7 +21,7 @@ send byte arrays back and forth.
 ## Prerequisites
 C services need to be compiled into the native firmware. As such, we need to
 build a custom envelope. Make sure to have finished the
-[custom envelope tutorial](./custom-envelope) before continuing.
+[custom envelope tutorial](../custom-envelope) before continuing.
 
 ## The C service
 The [template repository](https://github.com/toitlang/template-custom-envelope)

--- a/docs/tutorials/misc/custom-envelope.mdx
+++ b/docs/tutorials/misc/custom-envelope.mdx
@@ -54,7 +54,7 @@ the template to match your needs. For this tutorial we assume that you are
 using an ESP32 (the default), and that you will modify license, and the CI
 action at a later point. We will also keep the echo-service in the components
 directory, for now. You should remove it if you don't need it. See
-the [c-service tutorial](./c-service) for more information.
+the [c-service tutorial](../c-service) for more information.
 
 Update the toit SDK to your preferred version, and then initialize the submodules.
 The SDK version you want depends on your needs. If you want to use

--- a/docs/tutorials/network/cellular.mdx
+++ b/docs/tutorials/network/cellular.mdx
@@ -28,7 +28,7 @@ In later sections we will refer to [containers](../containers) and
 [services](../containers/services), but these are not strictly necessary.
 
 We will use HTTP to fetch data from the internet. There are
-[multiple](./http) [tutorials](./http-server) on this topic, but you
+[multiple](../http) [tutorials](../http-server) on this topic, but you
 should be able to follow this tutorial without having read them.
 
 ## Packages


### PR DESCRIPTION
Because of a quirk in the way URL paths are generated, if you're making a relative link from `index.mdx`, you specify it as:

```markdown
[text](./relative.mdx)
```

But if it's *not* in the index page - if it's a relative link to a regular page in the same directory - you need to use a double-dot:

```markdown
[text](../relative.mdx)
```

This commit fixes three such broken links.