### PR TITLE
Fix artemis fleet documentation.

### DIFF
--- a/docs/getstarted/fleet/reliability.mdx
+++ b/docs/getstarted/fleet/reliability.mdx
@@ -48,10 +48,10 @@ firmware-envelope: x64-linux
 containers: {}
 ```
 
-The max-offline value can also be set using the `toit` CLI:
+The max-offline value can also be set using the `artemis` CLI:
 
 ```bash
-toit device -d DEVICE-ID set-max-offline 1h
+artemis device -d DEVICE-ID set-max-offline 1h
 ```
 
 This configuration change is not permanent and will be lost with the next firmware update.


### PR DESCRIPTION
It said 'toit' instead of 'artemis'.

This page is copied over from the Artemis repository on each Artemis release,
     but we want to fix the documentation before the next release.