### PR TITLE
Migrate tutorials to integer GPIO numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           export TOIT_SDK=${{ steps.setup-toit.outputs.toit-install-dir }}/toit
           cd tools
-          $TOIT_SDK/bin/toit.pkg install
+          $TOIT_SDK/bin/toit pkg install
           ./run_all.sh
 
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
 
 env:
-  TOIT_VERSION: v2.0.0-alpha.148
+  TOIT_VERSION: v2.0.0-alpha.197
   BUILD_DIR: public
   HAS_PROTOBUF: false
   RUN_TESTS: true

--- a/docs/language/sdk/display.mdx
+++ b/docs/language/sdk/display.mdx
@@ -31,9 +31,9 @@ get-display -> PixelDisplay:
   scl := 4
   sda := 5
   bus := i2c.Bus
-    --sda=sda
-    --scl=scl
-    --frequency=800_000
+      --sda=sda
+      --scl=scl
+      --frequency=800_000
 
   devices := bus.scan
   if not devices.contains Ssd1306.I2C-ADDRESS:
@@ -154,14 +154,14 @@ main:
   display/PixelDisplay ::= get-display
 
   sans-10 := Style
-    --font = SANS-10-BOLD
-    --color = BLACK
-    --align-right
+      --font = SANS-10-BOLD
+      --color = BLACK
+      --align-right
 
   sans-24 := Style
-    --font = SANS-24-FONT
-    --color = BLACK
-    --align-center
+      --font = SANS-24-FONT
+      --color = BLACK
+      --align-center
 
   [
       Label --style=sans-10 --x=40 --y=30 --text="Hello from",

--- a/docs/language/sdk/display.mdx
+++ b/docs/language/sdk/display.mdx
@@ -23,14 +23,13 @@ pins and bus you are using to connect your display.
 Example contents of `get_display.toit`
 <!-- CODE FILENAME get_display.toit -->
 ```
-import gpio
 import i2c
 import ssd1306 show *
 import pixel-display show *
 
 get-display -> PixelDisplay:
-  scl := gpio.Pin 4
-  sda := gpio.Pin 5
+  scl := 4
+  sda := 5
   bus := i2c.Bus
     --sda=sda
     --scl=scl

--- a/docs/language/syntax.mdx
+++ b/docs/language/syntax.mdx
@@ -691,6 +691,6 @@ in the first clause of a `for`, `if`, or `while` statement.
   while data := reader.read:
     // data was not null.
 
-  if parsed := (int.parse str --on-error=: null):
+  if parsed := (int.parse str --if-error=: null):
     // parsed is not null and thus a valid number.
 ```

--- a/docs/language/tasks.mdx
+++ b/docs/language/tasks.mdx
@@ -111,11 +111,10 @@ The advantage of tasks in comparison with threads is that they take turns. To
 take an oversimplified example:
 
 ```
-import gpio
 import gpio.adc as gpio
 
 // The analog input is connected to pin 17.
-ADC1 ::= gpio.Adc (gpio.Pin.in 17)
+ADC1 ::= gpio.Adc 17
 
 class VoltageStatus:
   mv /int := 0

--- a/docs/language/typeconversion.mdx
+++ b/docs/language/typeconversion.mdx
@@ -76,8 +76,8 @@ main:
   s7 /string := "$(%0.3f 1.2) $(%0.2f PI)"
   print s7  // => "1.200 3.14"
   //or
-  print (f.stringify 3)
-  print (PI.stringify 2)
+  print (f.to-string --precision=3)
+  print (PI.to-string --precision=2)
 
   // Convert an integer to a floating point number
   f2 /float := i.to-float

--- a/docs/peripherals/drivers/bme280.mdx
+++ b/docs/peripherals/drivers/bme280.mdx
@@ -33,8 +33,8 @@ import i2c
 
 main:
   bus := i2c.Bus
-    --sda=21
-    --scl=22
+      --sda=21
+      --scl=22
 ```
 
 With the bus configured, we can specify how to address the BME280 device on the bus.
@@ -99,8 +99,8 @@ import bme280
 
 main:
   bus := i2c.Bus
-    --sda=21
-    --scl=22
+      --sda=21
+      --scl=22
 
   device := bus.device bme280.I2C-ADDRESS-ALT
 

--- a/docs/peripherals/drivers/bme280.mdx
+++ b/docs/peripherals/drivers/bme280.mdx
@@ -29,13 +29,12 @@ A detailed description of adding sensors using the Qwiic cable can be found [her
 First we're going to set up the I<sup>2</sup>C bus so we can connect the device:
 
 ```
-import gpio
 import i2c
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 ```
 
 With the bus configured, we can specify how to address the BME280 device on the bus.
@@ -95,14 +94,13 @@ Program measuring temperature, relative humidity, and atmospheric pressure
   with a BME280.
 */
 
-import gpio
 import i2c
 import bme280
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   device := bus.device bme280.I2C-ADDRESS-ALT
 

--- a/docs/peripherals/drivers/sparkfun_joystick.mdx
+++ b/docs/peripherals/drivers/sparkfun_joystick.mdx
@@ -23,13 +23,12 @@ The Joystick features an `ATtiny85` microcontroller with a custom firmware. As d
 We use a simple I<sup>2</sup>C setup, with pin `21` for `SDA` (blue) and pin `22` for `SCL` (yellow).
 
 ```
-import gpio
 import i2c
 
 main:
   bus := i2c.Bus
-      --sda=gpio.Pin 21
-      --scl=gpio.Pin 22
+      --sda=21
+      --scl=22
 ```
 
 ## Driver skeleton
@@ -264,15 +263,14 @@ class Joystick:
 **`main.toit`**
 
 ```
-import gpio
 import i2c
 
 import .qwiic-joystick
 
 main:
   bus := i2c.Bus
-      --sda=gpio.Pin 21
-      --scl=gpio.Pin 22
+      --sda=21
+      --scl=22
 
   device := bus.device Joystick.I2C-ADDRESS
 

--- a/docs/peripherals/gpio.mdx
+++ b/docs/peripherals/gpio.mdx
@@ -148,11 +148,10 @@ The ADC (analog-to-digital converter) can be used by importing `gpio.adc`:
 For example:
 
 ```
-import gpio
 import gpio.adc show Adc
 
 main:
-  adc := Adc (gpio.Pin 34)
+  adc := Adc 34
   print adc.get
   adc.close
 ```
@@ -172,11 +171,10 @@ pulse width.
 Example:
 
 ```
-import gpio
 import gpio.pwm
 
 main:
-  led := gpio.Pin 5
+  led := 5
   generator := pwm.Pwm --frequency=400
   channel := generator.start led
   duty-percent := 0

--- a/docs/peripherals/i2c.mdx
+++ b/docs/peripherals/i2c.mdx
@@ -5,13 +5,12 @@
 Toit exposes the peripheral through the [`i2c` library](https://libs.toit.io/i2c/library-summary).
 
 ```
-import gpio
 import i2c
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 ```
 
 Each device must have a unique address. The address can be found in the datasheet for the selected peripheral - it's an 7-bit integer.
@@ -19,13 +18,12 @@ Each device must have a unique address. The address can be found in the datashee
 In case of the Bosch [BME280 sensor](https://cdn.sparkfun.com/assets/e/7/3/b/1/BME280_Datasheet.pdf), the address is `0x76`:
 
 ```
-import gpio
 import i2c
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   device := bus.device 0x76
 ```
@@ -36,8 +34,8 @@ The default frequency of the I<sup>2</sup>C bus is 400kHz in Toit. This can be c
 
 ```
   i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
     --frequency=100000
 ```
 

--- a/docs/peripherals/i2c.mdx
+++ b/docs/peripherals/i2c.mdx
@@ -9,8 +9,8 @@ import i2c
 
 main:
   bus := i2c.Bus
-    --sda=21
-    --scl=22
+      --sda=21
+      --scl=22
 ```
 
 Each device must have a unique address. The address can be found in the datasheet for the selected peripheral - it's an 7-bit integer.
@@ -22,8 +22,8 @@ import i2c
 
 main:
   bus := i2c.Bus
-    --sda=21
-    --scl=22
+      --sda=21
+      --scl=22
 
   device := bus.device 0x76
 ```
@@ -34,9 +34,9 @@ The default frequency of the I<sup>2</sup>C bus is 400kHz in Toit. This can be c
 
 ```
   i2c.Bus
-    --sda=21
-    --scl=22
-    --frequency=100000
+      --sda=21
+      --scl=22
+      --frequency=100000
 ```
 
 Remember that when changing the frequency, the associated pull-up resistors may have to be changed as well.

--- a/docs/peripherals/spi.mdx
+++ b/docs/peripherals/spi.mdx
@@ -5,14 +5,13 @@
 Toit exposes the peripheral through the [`spi` library](https://libs.toit.io/spi/library-summary).
 
 ```
-import gpio
 import spi
 
 main:
   bus := spi.Bus
-    --miso=gpio.Pin 12
-    --mosi=gpio.Pin 13
-    --clock=gpio.Pin 14
+    --miso=12
+    --mosi=13
+    --clock=14
 ```
 
 When communicating with a device, a unique chip-select Pin is used to signal when the chip in question is addressed. In addition, it's important to not select a device frequency that exceeds the capabilities of device. The maximum frequency can be found in the datasheet for the selected peripheral.
@@ -20,16 +19,15 @@ When communicating with a device, a unique chip-select Pin is used to signal whe
 In case of the Bosch BME280 sensor, the maximum frequency is 10MHz:
 
 ```
-import gpio
 import spi
 
 main:
   bus := spi.Bus
-    --miso=gpio.Pin 12
-    --mosi=gpio.Pin 13
-    --clock=gpio.Pin 14
+    --miso=12
+    --mosi=13
+    --clock=14
 
   device := bus.device
-    --cs=gpio.Pin 15
+    --cs=15
     --frequency=10_000_000
 ```

--- a/docs/peripherals/spi.mdx
+++ b/docs/peripherals/spi.mdx
@@ -9,9 +9,9 @@ import spi
 
 main:
   bus := spi.Bus
-    --miso=12
-    --mosi=13
-    --clock=14
+      --miso=12
+      --mosi=13
+      --clock=14
 ```
 
 When communicating with a device, a unique chip-select Pin is used to signal when the chip in question is addressed. In addition, it's important to not select a device frequency that exceeds the capabilities of device. The maximum frequency can be found in the datasheet for the selected peripheral.
@@ -23,11 +23,11 @@ import spi
 
 main:
   bus := spi.Bus
-    --miso=12
-    --mosi=13
-    --clock=14
+      --miso=12
+      --mosi=13
+      --clock=14
 
   device := bus.device
-    --cs=15
-    --frequency=10_000_000
+      --cs=15
+      --frequency=10_000_000
 ```

--- a/docs/tutorials/ble/advertising.mdx
+++ b/docs/tutorials/ble/advertising.mdx
@@ -9,7 +9,7 @@ main:
   adapter := ble.Adapter
   peripheral := adapter.peripheral
 
-  data := ble.AdvertisementData
+  data := ble.Advertisement
 
   peripheral.start-advertise data
   sleep --ms=10000
@@ -27,7 +27,7 @@ main:
   adapter := ble.Adapter
   peripheral := adapter.peripheral
 
-  data := ble.AdvertisementData
+  data := ble.Advertisement
       --name="Toit device"
 
   peripheral.start-advertise data
@@ -50,9 +50,9 @@ main:
   adapter := ble.Adapter
   peripheral := adapter.peripheral
 
-  data := ble.AdvertisementData
+  data := ble.Advertisement
       --name="Toit device"
-      --service-classes=[BATTERY-SERVICE]
+      --services=[BATTERY-SERVICE]
 
   peripheral.start-advertise data
   sleep --ms=10000
@@ -82,10 +82,10 @@ main:
   adapter := ble.Adapter
   peripheral := adapter.peripheral
 
-  data := ble.AdvertisementData
+  data := ble.Advertisement
       --name="Toit device"
-      --service-classes=[BATTERY-SERVICE]
-      --manufacturer-data=#[0xFF, 0xFF, 't', 'o', 'i', 't']
+      --services=[BATTERY-SERVICE]
+      --manufacturer-specific=#['t', 'o', 'i', 't']
 
   peripheral.start-advertise data
   sleep --ms=1000000

--- a/docs/tutorials/ble/client.mdx
+++ b/docs/tutorials/ble/client.mdx
@@ -5,7 +5,7 @@ services implemented by the remote device as well as the service characteristics
 
 ## Connecting to a remote device
 
-In order for a BLE device to establish a connection to a remote device, the device must know the address. In most cases, the BLE device needs to discover the address which is done by scanning remote devices. The following example shows how to scan for the first remote device that implements a specific service.
+In order for a BLE device to establish a connection to a remote device, the device must know its identifier. In most cases, the BLE device needs to discover the identifier by scanning remote devices. The following example shows how to scan for the first remote device that implements a specific service.
 
 ```toit
 import ble
@@ -14,12 +14,12 @@ SCAN-DURATION ::= Duration --s=3
 
 find-with-service central/ble.Central service/ble.BleUuid:
   central.scan --duration=SCAN-DURATION: | device/ble.RemoteScannedDevice |
-    if device.data.service-classes.contains service:
-        return device.address
+    if device.data.services.contains service:
+      return device.identifier
   throw "no device found"
 ```
 
-With the address available, the connection can be established. In the following example, we use the `find-with-service` function to find a remote device with an advertised battery service and establish a connection to that device. Note that the device might also support services that are not explicitly advertised.
+With the identifier available, the connection can be established. In the following example, we use the `find-with-service` function to find a remote device with an advertised battery service and establish a connection to that device. Note that the device might also support services that are not explicitly advertised.
 
 ```toit
 // The battery service is defined in the Bluetooth specification.
@@ -32,8 +32,8 @@ main:
   adapter := ble.Adapter
   central := adapter.central
 
-  address := find-with-service central BATTERY-SERVICE
-  remote-device := central.connect address
+  identifier := find-with-service central BATTERY-SERVICE
+  remote-device := central.connect identifier
 ```
 
 ## Reading service characteristics
@@ -50,16 +50,16 @@ SCAN-DURATION   ::= Duration --s=3
 
 find-with-service central/ble.Central service/ble.BleUuid:
   central.scan --duration=SCAN-DURATION: | device/ble.RemoteScannedDevice |
-    if device.data.service-classes.contains service:
-        return device.address
+    if device.data.services.contains service:
+      return device.identifier
   throw "no device found"
 
 main:
   adapter := ble.Adapter
   central := adapter.central
 
-  address := find-with-service central BATTERY-SERVICE
-  remote-device := central.connect address
+  identifier := find-with-service central BATTERY-SERVICE
+  remote-device := central.connect identifier
   // Discover the battery service.
   services := remote-device.discover-services [BATTERY-SERVICE]
   battery-service/ble.RemoteService := services.first
@@ -72,5 +72,5 @@ main:
   value := battery-level-characteristic.read
   battery-level := value[0]
 
-  print "Battery level of $address: $battery-level%"
+  print "Battery level of $identifier: $battery-level%"
 ```

--- a/docs/tutorials/ble/scanning.mdx
+++ b/docs/tutorials/ble/scanning.mdx
@@ -21,7 +21,7 @@ Here the scan will run indefinitely.
 A scan can be used to create a list of remote devices that match a criteria, e.g. implement a specific service. A service is identified by a UUID with a select few services
 being assigned by [Bluetooth SIG](https://www.bluetooth.com/specifications/assigned-numbers/). As an example, the 16-bit UUID `0x180F` represents a battery service.
 
-The following example shows how to scan for 3 seconds for the addresses of remote devices that implement a battery service.
+The following example shows how to scan for 3 seconds for the identifiers of remote devices that implement a battery service.
 
 ```toit
 import ble
@@ -33,13 +33,13 @@ main:
   adapter := ble.Adapter
   central := adapter.central
 
-  addresses := []
+  identifiers := []
 
   central.scan --duration=SCAN-DURATION: | device/ble.RemoteScannedDevice |
-    if device.data.service-classes.contains BATTERY-SERVICE:
-      addresses.add device.address
+    if device.data.services.contains BATTERY-SERVICE:
+      identifiers.add device.identifier
 
-  print addresses
+  print identifiers
 ```
 
 ## Example: Mobile phone as a BLE device

--- a/docs/tutorials/hardware/adc.mdx
+++ b/docs/tutorials/hardware/adc.mdx
@@ -55,12 +55,10 @@ case the voltage between the two resistors should be 1.65V.
 Let's test this. Write (and Jaguar-`watch`) the following program:
 
 ``` toit
-import gpio
 import gpio.adc
 
 main:
-  pin := gpio.Pin 34
-  adc := adc.Adc pin
+  adc := adc.Adc 34
   256.repeat:
     print adc.get
     sleep --ms=500

--- a/docs/tutorials/hardware/bme280.mdx
+++ b/docs/tutorials/hardware/bme280.mdx
@@ -57,14 +57,13 @@ Create a new file `bme280.toit` and start `jag watch bme280.toit` to run
 the program whenever you save.
 
 ```toit
-import gpio
 import i2c
 import bme280
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 26
-    --scl=gpio.Pin 25
+    --sda=26
+    --scl=25
 
   // Use 'I2C-ADDRESS' if your device has address 0x76 (118).
   // Use 'I2C-ADDRESS-ALT' if your device has address 0x77 (119).

--- a/docs/tutorials/hardware/bme280.mdx
+++ b/docs/tutorials/hardware/bme280.mdx
@@ -62,8 +62,8 @@ import bme280
 
 main:
   bus := i2c.Bus
-    --sda=26
-    --scl=25
+      --sda=26
+      --scl=25
 
   // Use 'I2C-ADDRESS' if your device has address 0x76 (118).
   // Use 'I2C-ADDRESS-ALT' if your device has address 0x77 (119).

--- a/docs/tutorials/hardware/deepsleep.mdx
+++ b/docs/tutorials/hardware/deepsleep.mdx
@@ -110,12 +110,10 @@ tutorial for more information about the touch sensor.
 
 ```toit
 import esp32
-import gpio
 import gpio.touch as gpio
 
 main:
-  pin := gpio.Pin 32
-  touch := gpio.Touch pin
+  touch := gpio.Touch 32
   touch.threshold = 800
   esp32.enable-touchpad-wakeup
   esp32.deep-sleep (Duration --m=3)

--- a/docs/tutorials/hardware/dht11.mdx
+++ b/docs/tutorials/hardware/dht11.mdx
@@ -38,7 +38,7 @@ We are using the [dhtxx](https://pkg.toit.io/package/github.com%2Ftoitware%2Ftoi
 in your project directory:
 
 ```bash
-jag pkg install github.com/toitware/toit-dhtxx@v1.11
+jag pkg install github.com/toitware/toit-dhtxx@v1
 ```
 
 <Note>

--- a/docs/tutorials/hardware/dht11.mdx
+++ b/docs/tutorials/hardware/dht11.mdx
@@ -38,7 +38,7 @@ We are using the [dhtxx](https://pkg.toit.io/package/github.com%2Ftoitware%2Ftoi
 in your project directory:
 
 ```bash
-jag pkg install github.com/toitware/toit-dhtxx@v1
+jag pkg install github.com/toitware/toit-dhtxx@v1.11
 ```
 
 <Note>
@@ -53,13 +53,11 @@ Write and Jaguar-watch the following `dht11.toit` program:
 
 ```
 import dhtxx
-import gpio
 
 GPIO-PIN-NUM ::=  32
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  driver := dhtxx.Dht11 pin
+  driver := dhtxx.Dht11 GPIO-PIN-NUM
 
   (Duration --ms=1000).periodic:
     print driver.read

--- a/docs/tutorials/hardware/ds18b20.mdx
+++ b/docs/tutorials/hardware/ds18b20.mdx
@@ -52,7 +52,7 @@ We are using the [ds18b20](https://pkg.toit.io/package/github.com%2Ftoitware%2Ft
 package. To install it, run the following command in your project directory:
 
 ```bash
-jag pkg install github.com/toitware/toit-ds18b20@2.2
+jag pkg install github.com/toitware/toit-ds18b20@2
 ```
 
 <Note>

--- a/docs/tutorials/hardware/ds18b20.mdx
+++ b/docs/tutorials/hardware/ds18b20.mdx
@@ -52,7 +52,7 @@ We are using the [ds18b20](https://pkg.toit.io/package/github.com%2Ftoitware%2Ft
 package. To install it, run the following command in your project directory:
 
 ```bash
-jag pkg install github.com/toitware/toit-ds18b20@2
+jag pkg install github.com/toitware/toit-ds18b20@2.2
 ```
 
 <Note>
@@ -67,13 +67,11 @@ Write the following `ds18b20.toit` file and watch it with Jaguar.
 
 ``` toit
 import ds18b20 show Ds18b20
-import gpio
 
 GPIO-PIN-NUM ::= 32
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  ds18b20 := Ds18b20 pin
+  ds18b20 := Ds18b20 GPIO-PIN-NUM
 
   (Duration --ms=500).periodic:
     print "Temperature: $(%.2f ds18b20.read-temperature) C"

--- a/docs/tutorials/hardware/i2c.mdx
+++ b/docs/tutorials/hardware/i2c.mdx
@@ -48,12 +48,11 @@ and to list their addresses.
 Write an `i2c.toit` file and watch it with Jaguar:
 
 ```toit
-import gpio
 import i2c
 
 main:
-  scl := gpio.Pin 25
-  sda := gpio.Pin 26
+  scl := 25
+  sda := 26
   frequency := 100_000
 
   bus := i2c.Bus --sda=sda --scl=scl --frequency=frequency

--- a/docs/tutorials/hardware/neopixel.mdx
+++ b/docs/tutorials/hardware/neopixel.mdx
@@ -52,7 +52,7 @@ We are using the [pixel_strip](https://pkg.toit.io/package/github.com%2Ftoitware
 package. To install it, run the following command in your project directory:
 
 ```bash
-jag pkg install github.com/toitware/toit-pixel-strip@v1.3
+jag pkg install github.com/toitware/toit-pixel-strip@v1.4
 ```
 
 <Note>
@@ -68,14 +68,12 @@ Open a new file and save it as `neopixel.toit`,and watch it with Jaguar.
 Insert the following program:
 
 ```toit
-import gpio
 import pixel-strip show PixelStrip
 
 PIXELS ::= 12
 
 main:
-  pin := gpio.Pin 13
-  strip := PixelStrip.uart PIXELS --pin=pin
+  strip := PixelStrip.uart PIXELS --pin=13
 
   r := ByteArray PIXELS
   g := ByteArray PIXELS

--- a/docs/tutorials/hardware/neopixel.mdx
+++ b/docs/tutorials/hardware/neopixel.mdx
@@ -52,7 +52,7 @@ We are using the [pixel_strip](https://pkg.toit.io/package/github.com%2Ftoitware
 package. To install it, run the following command in your project directory:
 
 ```bash
-jag pkg install github.com/toitware/toit-pixel-strip@v1.4
+jag pkg install github.com/toitware/toit-pixel-strip@v1
 ```
 
 <Note>

--- a/docs/tutorials/hardware/potentiometer.mdx
+++ b/docs/tutorials/hardware/potentiometer.mdx
@@ -59,12 +59,10 @@ You can use the program from the ADC tutorial to see the voltage change when
 the knob is turned.
 
 ``` toit
-import gpio
 import gpio.adc
 
 main:
-  pin := gpio.Pin 34
-  adc := adc.Adc pin
+  adc := adc.Adc 34
   256.repeat:
     print "$(%1.3f adc.get)"
     sleep --ms=500

--- a/docs/tutorials/hardware/pwm-buzzer.mdx
+++ b/docs/tutorials/hardware/pwm-buzzer.mdx
@@ -32,7 +32,6 @@ Connect the buzzer as follows:
 Create a `buzzer.toit` file and watch it with Jaguar:
 
 ``` toit
-import gpio
 import gpio.pwm
 
 buzz pin --frequency --ms:
@@ -43,11 +42,10 @@ buzz pin --frequency --ms:
   generator.close
 
 main:
-  buzzer := gpio.Pin 14
+  buzzer := 14
   20.repeat:
     buzz buzzer --frequency=800 --ms=500
     buzz buzzer --frequency=1600 --ms=500
-  buzzer.close
 ```
 
 

--- a/docs/tutorials/hardware/pwm-led.mdx
+++ b/docs/tutorials/hardware/pwm-led.mdx
@@ -98,30 +98,25 @@ the frequency and the duty cycle, and it will emit the needed square wave.
 Here is the program that uses the PWM peripheral:
 
 ```toit
-import gpio
 import gpio.pwm
 
 main:
-  led := gpio.Pin 32
   generator := pwm.Pwm --frequency=400
-  channel := generator.start led
+  channel := generator.start 32
   channel.set-duty-factor 0.5
   sleep --ms=10_000
   channel.close
   generator.close
-  led.close
 ```
 
 A third of the code is just closing the resources we use (all the `close`
 calls). The more interesting lines are in the beginning:
 <!-- RESET CODE -->
-<!-- HIDDEN CODE import gpio -->
 <!-- HIDDEN CODE import gpio.pwm -->
 <!-- HIDDEN CODE main: -->
-<!-- HIDDEN CODE   led := gpio.Pin 32 -->
 ```
   generator := pwm.Pwm --frequency=400
-  channel := generator.start led
+  channel := generator.start 32
   channel.set-duty-factor 0.5
 ```
 
@@ -133,13 +128,11 @@ We can now play with the duty factor:
 
 <!-- RESET CODE -->
 ```toit
-import gpio
 import gpio.pwm
 
 main:
-  led := gpio.Pin 32
   generator := pwm.Pwm --frequency=400
-  channel := generator.start led
+  channel := generator.start 32
   duty-percent := 0
   step := 1
   while true:

--- a/docs/tutorials/hardware/pwm-servo.mdx
+++ b/docs/tutorials/hardware/pwm-servo.mdx
@@ -41,15 +41,13 @@ wave should be 50Hz.
 Write the following `servo.toit` program and run or watch it:
 
 ```toit
-import gpio
 import gpio.pwm
 
 main:
-  servo := gpio.Pin 12
   generator := pwm.Pwm --frequency=50
 
   // Start with the half-way angle.
-  channel := generator.start servo --duty-factor=0.075
+  channel := generator.start 12 --duty-factor=0.075
   sleep --ms=1500
 
   // Max angle.

--- a/docs/tutorials/hardware/rotary.mdx
+++ b/docs/tutorials/hardware/rotary.mdx
@@ -15,7 +15,7 @@ Typically a rotary encoder has two output signals:
 These two signals create square-wave pulses as you rotate the knob:
 
 **Clockwise rotation:  (CLK leads DT)**
-```
+```text
 CLK:   ┌───┐   ┌───┐
      ──┘   └───┘   └───┘
 DT:      ┌───┐   ┌───┐
@@ -23,7 +23,7 @@ DT:      ┌───┐   ┌───┐
 ```
 
 **Counter-clockwise rotation:  (DT leads CLK)**
-```
+```text
 CLK:     ┌───┐   ┌───┐
      ────┘   └───┘   └───┘
 DT:    ┌───┐   ┌───┐

--- a/docs/tutorials/hardware/rotary.mdx
+++ b/docs/tutorials/hardware/rotary.mdx
@@ -88,16 +88,14 @@ DT-PIN ::= 33
 SW-PIN ::= 25
 
 main:
-  // Set up the pins and the counter.
-  clk := gpio.Pin CLK-PIN
-  dt := gpio.Pin DT-PIN
+  // Set up the switch pin and the counter.
   sw := gpio.Pin SW-PIN --input --pull-down
 
   // Since we only need one channel, we can just configure the channel while
   // creating the pulse counter. If multiple channels are changing a
   // counter (unit), then we would need to create a list of channels and pass
   // that to the pulse-counter.Unit constructor.
-  counter := Unit clk --control-pin=dt
+  counter := Unit CLK-PIN --control-pin=DT-PIN
       --on-positive-edge=Channel.EDGE-INCREMENT
       --on-negative-edge=Channel.EDGE-DECREMENT
       --when-control-low=Channel.CONTROL-KEEP

--- a/docs/tutorials/hardware/ssd1306.mdx
+++ b/docs/tutorials/hardware/ssd1306.mdx
@@ -88,7 +88,6 @@ Enter the following program:
 
 ```toit
 import font show *
-import gpio
 import i2c
 import pixel-display show *
 import pixel-display.two-color show *
@@ -103,8 +102,8 @@ current-time:
   return "$(%02d now.h):$(%02d now.m):$(%02d now.s)"
 
 main:
-  sda := gpio.Pin 26
-  scl := gpio.Pin 25
+  sda := 26
+  scl := 25
   frequency := 400_000
 
   bus := i2c.Bus --sda=sda --scl=scl --frequency=frequency
@@ -210,15 +209,14 @@ Enter the following code into the new file:
 
 ```toit
 import pictogrammers-icons.size-48 as icons
-import gpio
 import i2c
 import pixel-display show *
 import pixel-display.two-color show *
 import ssd1306 show *
 
 get-display -> PixelDisplay:
-  sda := gpio.Pin 26
-  scl := gpio.Pin 25
+  sda := 26
+  scl := 25
   frequency := 400_000
 
   bus := i2c.Bus --sda=sda --scl=scl --frequency=frequency

--- a/docs/tutorials/hardware/touch.mdx
+++ b/docs/tutorials/hardware/touch.mdx
@@ -27,12 +27,10 @@ Create a new file `touch.toit` and start `jag watch touch.toit` to
 run the program whenever you save.
 
 ```toit
-import gpio
 import gpio.touch as gpio
 
 main:
-  pin := gpio.Pin 32
-  touch := gpio.Touch pin
+  touch := gpio.Touch 32
 
   while true:
     print (touch.read --raw)
@@ -47,12 +45,10 @@ Take a value that is in the seen range (for example 800) and use
 it in the following program as threshold.
 
 ```toit
-import gpio
 import gpio.touch as gpio
 
 main:
-  pin := gpio.Pin 32
-  touch := gpio.Touch pin
+  touch := gpio.Touch 32
 
   touch.threshold = 800
 
@@ -72,7 +68,6 @@ production and stored in the device's flash memory. You can also
 do this calibration dynamically:
 
 ```
-import gpio
 import gpio.touch as gpio
 
 ITERATIONS := 100
@@ -88,8 +83,7 @@ calibrate touch/gpio.Touch:
   touch.threshold = threshold
 
 main:
-  pin := gpio.Pin 32
-  touch := gpio.Touch pin
+  touch := gpio.Touch 32
 
   calibrate touch
 

--- a/docs/tutorials/hardware/ultra.mdx
+++ b/docs/tutorials/hardware/ultra.mdx
@@ -162,7 +162,7 @@ is thus more precise and uses less CPU.
 
 Install the package as usual with `jag pkg install`:
 ``` shell
-jag pkg install github.com/lask/toit-hc-sr04@v2.3
+jag pkg install github.com/lask/toit-hc-sr04@v2
 ```
 
 See the [package tutorial](../../setup/packages) for more information

--- a/docs/tutorials/hardware/ultra.mdx
+++ b/docs/tutorials/hardware/ultra.mdx
@@ -162,7 +162,7 @@ is thus more precise and uses less CPU.
 
 Install the package as usual with `jag pkg install`:
 ``` shell
-jag pkg install github.com/lask/toit-hc-sr04@v2
+jag pkg install github.com/lask/toit-hc-sr04@v2.3
 ```
 
 See the [package tutorial](../../setup/packages) for more information
@@ -171,16 +171,13 @@ about packages.
 We can now simplify the code:
 
 ``` toit
-import gpio
 import hc-sr04
 
 TRIGGER ::= 33
 ECHO ::= 32
 
 main:
-  trigger := gpio.Pin TRIGGER
-  echo := gpio.Pin ECHO
-  sensor := hc-sr04.Driver --echo=echo --trigger=trigger
+  sensor := hc-sr04.Driver --echo=ECHO --trigger=TRIGGER
 
   while true:
     distance := sensor.read-distance

--- a/docs/tutorials/mqtt/adafruit.mdx
+++ b/docs/tutorials/mqtt/adafruit.mdx
@@ -105,9 +105,9 @@ main:
   */
 
   options := mqtt.SessionOptions
-    --client-id = CLIENT-ID
-    --username = ADAFRUIT-IO-USERNAME
-    --password = ADAFRUIT-IO-KEY
+      --client-id = CLIENT-ID
+      --username = ADAFRUIT-IO-USERNAME
+      --password = ADAFRUIT-IO-KEY
 
   client.start --options=options
 

--- a/docs/tutorials/starter/weatherstation.mdx
+++ b/docs/tutorials/starter/weatherstation.mdx
@@ -25,14 +25,13 @@ Program measuring temperature, relative humidity, and atmospheric pressure
   with a BME280.
 */
 
-import gpio
 import i2c
 import bme280
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   device := bus.device bme280.I2C-ADDRESS-ALT
 
@@ -114,14 +113,13 @@ Program measuring temperature, relative humidity, and atmospheric pressure
   with a BME280.
 */
 
-import gpio
 import i2c
 import bme280
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   device := bus.device bme280.I2C-ADDRESS-ALT
 
@@ -166,15 +164,14 @@ Program measuring temperature, relative humidity, and atmospheric pressure
   with a BME280.
 */
 
-import gpio
 import i2c
 import bme280
 import esp32
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   device := bus.device bme280.I2C-ADDRESS-ALT
 

--- a/docs/tutorials/starter/weatherstation.mdx
+++ b/docs/tutorials/starter/weatherstation.mdx
@@ -30,8 +30,8 @@ import bme280
 
 main:
   bus := i2c.Bus
-    --sda=21
-    --scl=22
+      --sda=21
+      --scl=22
 
   device := bus.device bme280.I2C-ADDRESS-ALT
 
@@ -118,8 +118,8 @@ import bme280
 
 main:
   bus := i2c.Bus
-    --sda=21
-    --scl=22
+      --sda=21
+      --scl=22
 
   device := bus.device bme280.I2C-ADDRESS-ALT
 
@@ -170,8 +170,8 @@ import esp32
 
 main:
   bus := i2c.Bus
-    --sda=21
-    --scl=22
+      --sda=21
+      --scl=22
 
   device := bus.device bme280.I2C-ADDRESS-ALT
 

--- a/tools/package.lock
+++ b/tools/package.lock
@@ -1,171 +1,172 @@
-sdk: ^2.0.0-alpha.145
+sdk: ^2.0.0-alpha.196
 prefixes:
-  bme280: bme280-driver
-  cellular: cellular
-  certificate_roots: toit-cert-roots
-  cli: pkg-cli
-  dhtxx: toit-dhtxx
-  ds18b20: toit-ds18b20
-  font_x11_adobe: pkg-font-x11-adobe
-  hc_sr04: toit-hc-sr04
-  host: pkg-host
-  http: pkg-http
-  morse: toit-morse
-  mqtt: mqtt
-  ntp: pkg-ntp
-  one_wire: toit-1-wire
-  pictogrammers_icons: toit-icons-pictogrammers
-  pixel_display: toit-pixel-display
-  pixel_strip: toit-pixel-strip
-  qubitro: toit-qubitro
-  ssd1306: toit-ssd1306
-  supabase: toit-supabase
-  telegram: toit-telegram
-  watchdog: toit-watchdog
+  bme280: github.com/toitware/bme280-driver-1
+  cellular: github.com/toitware/cellular-2
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  cli: github.com/toitlang/pkg-cli-2
+  dhtxx: github.com/toitware/toit-dhtxx-1
+  ds18b20: github.com/toitware/toit-ds18b20-2
+  font_x11_adobe: github.com/toitlang/pkg-font-x11-adobe-0
+  hc_sr04: github.com/lask/toit-hc-sr04-2
+  host: github.com/toitlang/pkg-host-1
+  http: github.com/toitlang/pkg-http-2
+  morse: github.com/toitware/toit-morse-1
+  mqtt: github.com/toitware/mqtt-2
+  ntp: github.com/toitlang/pkg-ntp-1
+  one_wire: github.com/toitware/toit-1-wire-2
+  pictogrammers_icons: github.com/toitware/toit-icons-pictogrammers-1
+  pixel_display: github.com/toitware/toit-pixel-display-2
+  pixel_strip: github.com/toitware/toit-pixel-strip-1
+  qubitro: github.com/kasperl/toit-qubitro-0
+  ssd1306: github.com/toitware/toit-ssd1306-2
+  supabase: github.com/toitware/toit-supabase-0
+  telegram: github.com/floitsch/toit-telegram-0
+  watchdog: github.com/toitware/toit-watchdog-1
 packages:
-  bme280-driver:
-    url: github.com/toitware/bme280-driver
-    name: bme280
-    version: 1.0.0
-    hash: 65b88ac19a5e2b48627a2dbae6d7757ae45c502c
-  cellular:
-    url: github.com/toitware/cellular
-    name: cellular
-    version: 2.2.3
-    hash: ea31024e16ebf62c4a376c83d510bc27c5d00762
-  mqtt:
-    url: github.com/toitware/mqtt
-    name: mqtt
-    version: 2.9.0
-    hash: ab5cda567a9b35e09ec0773ec08f4cb0ee90873d
-  pkg-cli:
-    url: github.com/toitlang/pkg-cli
-    name: cli
-    version: 1.8.0
-    hash: 73c8aabb60a6f5f304566a1e781d7b025aa17e9b
-    prefixes:
-      fs: pkg-fs
-      host: pkg-host
-  pkg-font-x11-adobe:
-    url: github.com/toitlang/pkg-font-x11-adobe
-    name: font_x11_adobe
-    version: 0.1.0
-    hash: f844400722165252148f087cdf189abab0a47f3d
-  pkg-fs:
-    url: github.com/toitlang/pkg-fs
-    name: fs
-    version: 2.3.1
-    hash: 60836d4500317af2093d59d50c117d612c33f1fa
-    prefixes:
-      host: pkg-host
-  pkg-host:
-    url: github.com/toitlang/pkg-host
-    name: host
-    version: 1.15.1
-    hash: ff187c2c19d695e66c3dc1d9c09b4dc6bec09088
-  pkg-http:
-    url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.7.2
-    hash: 614dd0f374e70aab09f12e9466a35b779b9a8d63
-  pkg-ntp:
-    url: github.com/toitlang/pkg-ntp
-    name: ntp
-    version: 1.1.0
-    hash: e69bb1abc0d3d4aa7642eec3360e52744e4d011d
-  toit-1-wire:
-    url: github.com/toitware/toit-1-wire
-    name: one_wire
-    version: 2.2.0
-    hash: 8e15ea2315dc114824e6728a10e1260b4f388176
-  toit-artemis:
-    url: github.com/toitware/toit-artemis
-    name: artemis
-    version: 0.8.3
-    hash: c65898c512ec79173b523add1c8d13ec203b6e7e
-  toit-cert-roots:
-    url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
-  toit-dhtxx:
-    url: github.com/toitware/toit-dhtxx
-    name: dhtxx
-    version: 1.4.0
-    hash: bf69ad9ac348324803caf8919cf7e9f34aa3d343
-  toit-ds18b20:
-    url: github.com/toitware/toit-ds18b20
-    name: ds18b20
-    version: 2.1.0
-    hash: 09534f8f474d595620531df23b61e9707e1f5483
-    prefixes:
-      one_wire: toit-1-wire
-  toit-hc-sr04:
-    url: github.com/lask/toit-hc-sr04
-    name: hc_sr04
-    version: 2.1.1
-    hash: da8389adec9f012999c385b69bc42e26e19b51fa
-  toit-icons-pictogrammers:
-    url: github.com/toitware/toit-icons-pictogrammers
-    name: pictogrammers_icons
-    version: 1.0.0
-    hash: 5ac660cc480d5da1fec72e1b24d425ce978419b7
-  toit-morse:
-    url: github.com/toitware/toit-morse
-    name: morse
-    version: 1.0.6
-    hash: f9f6ba3a04984db16887d7a1051ada8ad30d7db2
-  toit-pixel-display:
-    url: github.com/toitware/toit-pixel-display
-    name: pixel_display
-    version: 2.8.0
-    hash: d7789ab67f6f0cde4e6df40b7aac88a56b871ca7
-    prefixes:
-      png-tools: toit-png-tools
-  toit-pixel-strip:
-    url: github.com/toitware/toit-pixel-strip
-    name: pixel_strip
-    version: 0.3.0
-    hash: 6afc86f08e0e751a58a4f56b119d5e14464a4762
-  toit-png-tools:
-    url: github.com/toitware/toit-png-tools
-    name: png-tools
-    version: 1.0.0
-    hash: ee472ac9d4333a138206f9d3a817d3c5432d6f87
-  toit-qubitro:
-    url: github.com/kasperl/toit-qubitro
-    name: qubitro
-    version: 0.4.1
-    hash: fb720f5ac40d91e0ae8714f07e8a81c4bf00a3fb
-    prefixes:
-      artemis: toit-artemis
-      certificate_roots: toit-cert-roots
-      mqtt: mqtt
-  toit-ssd1306:
-    url: github.com/toitware/toit-ssd1306
-    name: ssd1306
-    version: 2.0.1
-    hash: ee2e6e699daa86d961538775aaea642a839025b7
-    prefixes:
-      pixel_display: toit-pixel-display
-  toit-supabase:
-    url: github.com/toitware/toit-supabase
-    name: supabase
-    version: 0.3.1
-    hash: bcf10850b0fae0592bb0af6563fb994cececb8f9
-    prefixes:
-      host: pkg-host
-      http: pkg-http
-  toit-telegram:
-    url: github.com/floitsch/toit-telegram
-    name: telegram
-    version: 0.5.3
+  github.com/floitsch/toit-telegram-0:
     hash: 438903d35f6eae1faa7573f5f51b4fa5db3b7dff
     prefixes:
-      certificate_roots: toit-cert-roots
-      http: pkg-http
-  toit-watchdog:
-    url: github.com/toitware/toit-watchdog
-    name: watchdog
+      certificate_roots: github.com/toitware/toit-cert-roots-1
+      http: github.com/toitlang/pkg-http-2
+    url: github.com/floitsch/toit-telegram
+    version: 0.5.3
+  github.com/kasperl/toit-qubitro-0:
+    hash: fb720f5ac40d91e0ae8714f07e8a81c4bf00a3fb
+    prefixes:
+      artemis: github.com/toitware/toit-artemis-0
+      certificate_roots: github.com/toitware/toit-cert-roots-1
+      mqtt: github.com/toitware/mqtt-2
+    url: github.com/kasperl/toit-qubitro
+    version: 0.4.1
+  github.com/lask/toit-hc-sr04-2:
+    hash: 9a6eb8a69b1dd27351d2ee4994366b584c6d1535
+    prefixes:
+      sensors: github.com/toitware/toit-sensors-1
+    url: github.com/lask/toit-hc-sr04
+    version: 2.3.0
+  github.com/toitlang/pkg-cli-2:
+    hash: 8f58b041d55440916a2527899df505f6c6259b20
+    prefixes:
+      desktop: github.com/toitlang/pkg-desktop-1
+      fs: github.com/toitlang/pkg-fs-2
+      host: github.com/toitlang/pkg-host-1
+      lockfile: github.com/toitware/toit-lockfile-1
+    url: github.com/toitlang/pkg-cli
+    version: 2.17.0
+  github.com/toitlang/pkg-desktop-1:
+    hash: d6ad1d5c25e16d0c2910a132acba426251b5d87f
+    prefixes:
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-desktop
+    version: 1.1.0
+  github.com/toitlang/pkg-font-x11-adobe-0:
+    hash: f844400722165252148f087cdf189abab0a47f3d
+    url: github.com/toitlang/pkg-font-x11-adobe
+    version: 0.1.0
+  github.com/toitlang/pkg-fs-2:
+    hash: 60836d4500317af2093d59d50c117d612c33f1fa
+    prefixes:
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-fs
+    version: 2.3.1
+  github.com/toitlang/pkg-host-1:
+    hash: d7a30b86c73cf8d9cd5dd0211031c76b68706738
+    url: github.com/toitlang/pkg-host
+    version: 1.19.0
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
+    url: github.com/toitlang/pkg-http
+    version: 2.12.0
+  github.com/toitlang/pkg-ntp-1:
+    hash: e69bb1abc0d3d4aa7642eec3360e52744e4d011d
+    url: github.com/toitlang/pkg-ntp
+    version: 1.1.0
+  github.com/toitware/bme280-driver-1:
+    hash: ca9c6451532139d506299fba8c0915cd3001982e
+    prefixes:
+      sensors: github.com/toitware/toit-sensors-1
+    url: github.com/toitware/bme280-driver
+    version: 1.2.0
+  github.com/toitware/cellular-2:
+    hash: b8a154f734883c38d53be69ec48a3460981a83b4
+    url: github.com/toitware/cellular
+    version: 2.8.0
+  github.com/toitware/mqtt-2:
+    hash: ac50d868a578c45003956da66075be5158a78c7a
+    url: github.com/toitware/mqtt
+    version: 2.13.1
+  github.com/toitware/toit-1-wire-2:
+    hash: 86fd681d33aa819ed4a23b1aae0a3baafe68e641
+    url: github.com/toitware/toit-1-wire
+    version: 2.6.0
+  github.com/toitware/toit-artemis-0:
+    hash: c65898c512ec79173b523add1c8d13ec203b6e7e
+    url: github.com/toitware/toit-artemis
+    version: 0.8.3
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
+    url: github.com/toitware/toit-cert-roots
+    version: 1.11.0
+  github.com/toitware/toit-dhtxx-1:
+    hash: e698231a28d781efac10c3dc30b63d8f1a16cba8
+    prefixes:
+      sensors: github.com/toitware/toit-sensors-1
+    url: github.com/toitware/toit-dhtxx
+    version: 1.11.0
+  github.com/toitware/toit-ds18b20-2:
+    hash: 8d3e0dfe0b78c6a365cd58b2f8ca96af65cb0d75
+    prefixes:
+      one_wire: github.com/toitware/toit-1-wire-2
+      sensors: github.com/toitware/toit-sensors-1
+    url: github.com/toitware/toit-ds18b20
+    version: 2.2.0
+  github.com/toitware/toit-icons-pictogrammers-1:
+    hash: 5ac660cc480d5da1fec72e1b24d425ce978419b7
+    url: github.com/toitware/toit-icons-pictogrammers
+    version: 1.0.0
+  github.com/toitware/toit-lockfile-1:
+    hash: 47ddd8c13811e6cc368d6fef8f383b855f9d0ada
+    prefixes:
+      fs: github.com/toitlang/pkg-fs-2
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitware/toit-lockfile
+    version: 1.0.0
+  github.com/toitware/toit-morse-1:
+    hash: f9f6ba3a04984db16887d7a1051ada8ad30d7db2
+    url: github.com/toitware/toit-morse
+    version: 1.0.6
+  github.com/toitware/toit-pixel-display-2:
+    hash: 59a4be9f0e6aa2321c6a032da44776f59af364b5
+    prefixes:
+      png-tools: github.com/toitware/toit-png-tools-1
+    url: github.com/toitware/toit-pixel-display
+    version: 2.11.0
+  github.com/toitware/toit-pixel-strip-1:
+    hash: e7b0942f6cdc8f5575a3d7e78b74fef1544117c5
+    url: github.com/toitware/toit-pixel-strip
     version: 1.4.0
-    hash: 3dccabf427af3a8ba3ef48429244ece0956fa684
+  github.com/toitware/toit-png-tools-1:
+    hash: ee472ac9d4333a138206f9d3a817d3c5432d6f87
+    url: github.com/toitware/toit-png-tools
+    version: 1.0.0
+  github.com/toitware/toit-sensors-1:
+    hash: f9f5662a0f21016259ff6907419e54d00223714a
+    url: github.com/toitware/toit-sensors
+    version: 1.0.0
+  github.com/toitware/toit-ssd1306-2:
+    hash: 444a71ef89a06674c7df5d24754663ec9aeae267
+    prefixes:
+      pixel_display: github.com/toitware/toit-pixel-display-2
+    url: github.com/toitware/toit-ssd1306
+    version: 2.1.0
+  github.com/toitware/toit-supabase-0:
+    hash: bcf10850b0fae0592bb0af6563fb994cececb8f9
+    prefixes:
+      host: github.com/toitlang/pkg-host-1
+      http: github.com/toitlang/pkg-http-2
+    url: github.com/toitware/toit-supabase
+    version: 0.3.1
+  github.com/toitware/toit-watchdog-1:
+    hash: 2621b25fca45f4f91c0b951f3658f3c18821edc4
+    url: github.com/toitware/toit-watchdog
+    version: 1.4.1

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -1,67 +1,67 @@
 dependencies:
   bme280:
     url: github.com/toitware/bme280-driver
-    version: ^1.0.0
+    version: ^1.2.0
   cellular:
     url: github.com/toitware/cellular
-    version: ^2.2.3
+    version: ^2.8.0
   certificate_roots:
     url: github.com/toitware/toit-cert-roots
-    version: ^1.6.1
+    version: ^1.11.0
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^1.8.0
+    version: ^2.17.0
   dhtxx:
     url: github.com/toitware/toit-dhtxx
-    version: ^1.4.0
+    version: ^1.11.0
   ds18b20:
     url: github.com/toitware/toit-ds18b20
-    version: ^2.1.0
+    version: ^2.2.0
   font_x11_adobe:
     url: github.com/toitlang/pkg-font-x11-adobe
-    version: ^0.1.0
+    version: ~0.1.0
   hc_sr04:
     url: github.com/lask/toit-hc-sr04
-    version: ^2.1.1
+    version: ^2.3.0
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.15.1
+    version: ^1.19.0
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.7.2
+    version: ^2.12.0
   morse:
     url: github.com/toitware/toit-morse
     version: ^1.0.6
   mqtt:
     url: github.com/toitware/mqtt
-    version: ^2.9.0
+    version: ^2.13.1
   ntp:
     url: github.com/toitlang/pkg-ntp
     version: ^1.1.0
   one_wire:
     url: github.com/toitware/toit-1-wire
-    version: ^2.2.0
+    version: ^2.6.0
   pictogrammers_icons:
     url: github.com/toitware/toit-icons-pictogrammers
     version: ^1.0.0
   pixel_display:
     url: github.com/toitware/toit-pixel-display
-    version: ^2.8.0
+    version: ^2.11.0
   pixel_strip:
     url: github.com/toitware/toit-pixel-strip
-    version: ^0.3.0
+    version: ^1.4.0
   qubitro:
     url: github.com/kasperl/toit-qubitro
-    version: ^0.4.1
+    version: ~0.4.1
   ssd1306:
     url: github.com/toitware/toit-ssd1306
-    version: ^2.0.1
+    version: ^2.1.0
   supabase:
     url: github.com/toitware/toit-supabase
-    version: ^0.3.1
+    version: ~0.3.1
   telegram:
     url: github.com/floitsch/toit-telegram
-    version: ^0.5.3
+    version: ~0.5.3
   watchdog:
     url: github.com/toitware/toit-watchdog
-    version: ^1.4.0
+    version: ^1.4.1

--- a/tools/run_snippets.toit
+++ b/tools/run_snippets.toit
@@ -33,8 +33,15 @@ import host.os
 DEFAULT-OUTPUT ::= "snippet.toit"
 
 THINGS-THAT-WONT-RUN-ON-SERVER ::= [
+  "import bme280",
+  "import dhtxx",
+  "import ds18b20",
   "import gpio",
+  "import hc-sr04",
+  "import i2c",
+  "import spi",
   "import pixel-display",
+  "import pixel-strip",
   "import mqtt",
   "import ble",
   "import esp32",
@@ -171,9 +178,9 @@ class State:
       result = pipe.system "$toit analyze $werror-flag $filename"
     else:
       result = pipe.system "$toit run $werror-flag -- $filename"
-    before-kebabify := file.read-content filename
+    before-kebabify := file.read-contents filename
     pipe.system "$toit tool kebabify code $filename"
-    after-kebabify := file.read-content filename
+    after-kebabify := file.read-contents filename
     if before-kebabify != after-kebabify:
       throw "Kebabify changed the file $filename"
     check-only = false

--- a/tutorial_code/adc/adc_v1.toit
+++ b/tutorial_code/adc/adc_v1.toit
@@ -2,12 +2,10 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.adc
 
 main:
-  pin := gpio.Pin 34
-  adc := adc.Adc pin
+  adc := adc.Adc 34
   256.repeat:
     print adc.get
     sleep --ms=500

--- a/tutorial_code/adc/adc_v2.toit
+++ b/tutorial_code/adc/adc_v2.toit
@@ -2,12 +2,10 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.adc
 
 main:
-  pin := gpio.Pin 34
-  adc := adc.Adc pin
+  adc := adc.Adc 34
   256.repeat:
     print "$(%1.3f adc.get)"
     sleep --ms=500

--- a/tutorial_code/bme280/bme280.toit
+++ b/tutorial_code/bme280/bme280.toit
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import i2c
 import bme280
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 25
-    --scl=gpio.Pin 26
+    --sda=25
+    --scl=26
 
   // Use 'I2C_ADDRESS' if your device has address 0x76 (118).
   // Use 'I2C_ADDRESS_ALT' if your device has address 0x77 (119).

--- a/tutorial_code/bme280/bme280.toit
+++ b/tutorial_code/bme280/bme280.toit
@@ -7,8 +7,8 @@ import bme280
 
 main:
   bus := i2c.Bus
-    --sda=25
-    --scl=26
+      --sda=25
+      --scl=26
 
   // Use 'I2C_ADDRESS' if your device has address 0x76 (118).
   // Use 'I2C_ADDRESS_ALT' if your device has address 0x77 (119).

--- a/tutorial_code/bme280/bme280_alt.toit
+++ b/tutorial_code/bme280/bme280_alt.toit
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import i2c
 import bme280
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 26
-    --scl=gpio.Pin 25
+    --sda=26
+    --scl=25
 
   // Use 'I2C_ADDRESS' if your device has address 0x76 (118).
   // Use 'I2C_ADDRESS_ALT' if your device has address 0x77 (119).

--- a/tutorial_code/bme280/bme280_alt.toit
+++ b/tutorial_code/bme280/bme280_alt.toit
@@ -7,8 +7,8 @@ import bme280
 
 main:
   bus := i2c.Bus
-    --sda=26
-    --scl=25
+      --sda=26
+      --scl=25
 
   // Use 'I2C_ADDRESS' if your device has address 0x76 (118).
   // Use 'I2C_ADDRESS_ALT' if your device has address 0x77 (119).

--- a/tutorial_code/bme280/package.lock
+++ b/tutorial_code/bme280/package.lock
@@ -1,8 +1,14 @@
+sdk: ^2.0.0-alpha.196
 prefixes:
-  bme280: bme280-driver
+  bme280: github.com/toitware/bme280-driver-1
 packages:
-  bme280-driver:
+  github.com/toitware/bme280-driver-1:
+    hash: ca9c6451532139d506299fba8c0915cd3001982e
+    prefixes:
+      sensors: github.com/toitware/toit-sensors-1
     url: github.com/toitware/bme280-driver
-    name: bme280
+    version: 1.2.0
+  github.com/toitware/toit-sensors-1:
+    hash: f9f5662a0f21016259ff6907419e54d00223714a
+    url: github.com/toitware/toit-sensors
     version: 1.0.0
-    hash: 65b88ac19a5e2b48627a2dbae6d7757ae45c502c

--- a/tutorial_code/bme280/package.yaml
+++ b/tutorial_code/bme280/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   bme280:
     url: github.com/toitware/bme280-driver
-    version: ^1.0.0
+    version: ^1.2.0

--- a/tutorial_code/buzzer/buzzer_v1.toit
+++ b/tutorial_code/buzzer/buzzer_v1.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.pwm
 
 buzz pin --frequency --ms:
@@ -13,8 +12,7 @@ buzz pin --frequency --ms:
   generator.close
 
 main:
-  buzzer := gpio.Pin 14
+  buzzer := 14
   20.repeat:
     buzz buzzer --frequency=800 --ms=500
     buzz buzzer --frequency=1600 --ms=500
-  buzzer.close

--- a/tutorial_code/cellular/package.lock
+++ b/tutorial_code/cellular/package.lock
@@ -1,21 +1,18 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.196
 prefixes:
-  cellular: cellular
-  certificate_roots: toit-cert-roots
-  http: pkg-http
+  cellular: github.com/toitware/cellular-2
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  http: github.com/toitlang/pkg-http-2
 packages:
-  cellular:
-    url: github.com/toitware/cellular
-    name: cellular
-    version: 2.2.0
-    hash: 2f50148ed01e28ab2c3de09182b09f67ffcde776
-  pkg-http:
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
     url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.7.1
-    hash: 54a5bb458d9fc9305e839b878e6de3b456f5c4a6
-  toit-cert-roots:
+    version: 2.12.0
+  github.com/toitware/cellular-2:
+    hash: b8a154f734883c38d53be69ec48a3460981a83b4
+    url: github.com/toitware/cellular
+    version: 2.8.0
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
     url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
+    version: 1.11.0

--- a/tutorial_code/cellular/package.yaml
+++ b/tutorial_code/cellular/package.yaml
@@ -1,10 +1,10 @@
 dependencies:
   cellular:
     url: github.com/toitware/cellular
-    version: ^2.2.0
+    version: ^2.8.0
   certificate_roots:
     url: github.com/toitware/toit-cert-roots
-    version: ^1.6.1
+    version: ^1.11.0
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.7.1
+    version: ^2.12.0

--- a/tutorial_code/dht11/dht11.toit
+++ b/tutorial_code/dht11/dht11.toit
@@ -3,13 +3,11 @@
 // be found in the LICENSE_BSD0 file.
 
 import dhtxx
-import gpio
 
 GPIO-PIN-NUM ::=  32
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  driver := dhtxx.Dht11 pin
+  driver := dhtxx.Dht11 GPIO-PIN-NUM
 
   (Duration --ms=500).periodic:
     print driver.read

--- a/tutorial_code/dht11/dht11.toit
+++ b/tutorial_code/dht11/dht11.toit
@@ -9,5 +9,5 @@ GPIO-PIN-NUM ::=  32
 main:
   driver := dhtxx.Dht11 GPIO-PIN-NUM
 
-  (Duration --ms=500).periodic:
+  (Duration --ms=1000).periodic:
     print driver.read

--- a/tutorial_code/dht11/package.lock
+++ b/tutorial_code/dht11/package.lock
@@ -1,9 +1,14 @@
-sdk: ^2.0.0-alpha.1
+sdk: ^2.0.0-alpha.196
 prefixes:
-  dhtxx: toit-dhtxx
+  dhtxx: github.com/toitware/toit-dhtxx-1
 packages:
-  toit-dhtxx:
+  github.com/toitware/toit-dhtxx-1:
+    hash: e698231a28d781efac10c3dc30b63d8f1a16cba8
+    prefixes:
+      sensors: github.com/toitware/toit-sensors-1
     url: github.com/toitware/toit-dhtxx
-    name: dhtxx
-    version: 1.4.0
-    hash: bf69ad9ac348324803caf8919cf7e9f34aa3d343
+    version: 1.11.0
+  github.com/toitware/toit-sensors-1:
+    hash: f9f5662a0f21016259ff6907419e54d00223714a
+    url: github.com/toitware/toit-sensors
+    version: 1.0.0

--- a/tutorial_code/dht11/package.yaml
+++ b/tutorial_code/dht11/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   dhtxx:
     url: github.com/toitware/toit-dhtxx
-    version: ^1.4.0
+    version: ^1.11.0

--- a/tutorial_code/ds18b20/ds18b20.toit
+++ b/tutorial_code/ds18b20/ds18b20.toit
@@ -3,13 +3,11 @@
 // be found in the LICENSE_BSD0 file.
 
 import ds18b20 show Ds18b20
-import gpio
 
 GPIO-PIN-NUM ::= 32
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  ds18b20 := Ds18b20 pin
+  ds18b20 := Ds18b20 GPIO-PIN-NUM
 
   (Duration --ms=500).periodic:
     print "Temperature: $(%.2f ds18b20.read-temperature) C"

--- a/tutorial_code/ds18b20/package.lock
+++ b/tutorial_code/ds18b20/package.lock
@@ -1,16 +1,19 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.196
 prefixes:
-  ds18b20: toit-ds18b20
+  ds18b20: github.com/toitware/toit-ds18b20-2
 packages:
-  toit-1-wire:
+  github.com/toitware/toit-1-wire-2:
+    hash: 86fd681d33aa819ed4a23b1aae0a3baafe68e641
     url: github.com/toitware/toit-1-wire
-    name: one_wire
-    version: 2.2.0
-    hash: 8e15ea2315dc114824e6728a10e1260b4f388176
-  toit-ds18b20:
-    url: github.com/toitware/toit-ds18b20
-    name: ds18b20
-    version: 2.1.0
-    hash: 09534f8f474d595620531df23b61e9707e1f5483
+    version: 2.6.0
+  github.com/toitware/toit-ds18b20-2:
+    hash: 8d3e0dfe0b78c6a365cd58b2f8ca96af65cb0d75
     prefixes:
-      one_wire: toit-1-wire
+      one_wire: github.com/toitware/toit-1-wire-2
+      sensors: github.com/toitware/toit-sensors-1
+    url: github.com/toitware/toit-ds18b20
+    version: 2.2.0
+  github.com/toitware/toit-sensors-1:
+    hash: f9f5662a0f21016259ff6907419e54d00223714a
+    url: github.com/toitware/toit-sensors
+    version: 1.0.0

--- a/tutorial_code/ds18b20/package.yaml
+++ b/tutorial_code/ds18b20/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   ds18b20:
     url: github.com/toitware/toit-ds18b20
-    version: ^2.1.0
+    version: ^2.2.0

--- a/tutorial_code/google-sheets/package.lock
+++ b/tutorial_code/google-sheets/package.lock
@@ -1,15 +1,13 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.190
 prefixes:
-  certificate_roots: toit-cert-roots
-  http: pkg-http
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  http: github.com/toitlang/pkg-http-2
 packages:
-  pkg-http:
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
     url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.7.1
-    hash: 54a5bb458d9fc9305e839b878e6de3b456f5c4a6
-  toit-cert-roots:
+    version: 2.12.0
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
     url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
+    version: 1.11.0

--- a/tutorial_code/google-sheets/package.yaml
+++ b/tutorial_code/google-sheets/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   certificate_roots:
     url: github.com/toitware/toit-cert-roots
-    version: ^1.6.1
+    version: ^1.11.0
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.7.1
+    version: ^2.12.0

--- a/tutorial_code/http-file-server/package.lock
+++ b/tutorial_code/http-file-server/package.lock
@@ -1,15 +1,13 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.190
 prefixes:
-  host: pkg-host
-  http: pkg-http
+  host: github.com/toitlang/pkg-host-1
+  http: github.com/toitlang/pkg-http-2
 packages:
-  pkg-host:
+  github.com/toitlang/pkg-host-1:
+    hash: d7a30b86c73cf8d9cd5dd0211031c76b68706738
     url: github.com/toitlang/pkg-host
-    name: host
-    version: 1.15.1
-    hash: ff187c2c19d695e66c3dc1d9c09b4dc6bec09088
-  pkg-http:
+    version: 1.19.0
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
     url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.7.1
-    hash: 54a5bb458d9fc9305e839b878e6de3b456f5c4a6
+    version: 2.12.0

--- a/tutorial_code/http-file-server/package.yaml
+++ b/tutorial_code/http-file-server/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.15.1
+    version: ^1.19.0
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.7.1
+    version: ^2.12.0

--- a/tutorial_code/http-server/package.lock
+++ b/tutorial_code/http-server/package.lock
@@ -1,9 +1,8 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.190
 prefixes:
-  http: pkg-http
+  http: github.com/toitlang/pkg-http-2
 packages:
-  pkg-http:
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
     url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.7.1
-    hash: 54a5bb458d9fc9305e839b878e6de3b456f5c4a6
+    version: 2.12.0

--- a/tutorial_code/http-server/package.yaml
+++ b/tutorial_code/http-server/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.7.1
+    version: ^2.12.0

--- a/tutorial_code/http/package.lock
+++ b/tutorial_code/http/package.lock
@@ -1,15 +1,13 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.190
 prefixes:
-  certificate_roots: toit-cert-roots
-  http: pkg-http
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  http: github.com/toitlang/pkg-http-2
 packages:
-  pkg-http:
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
     url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.7.1
-    hash: 54a5bb458d9fc9305e839b878e6de3b456f5c4a6
-  toit-cert-roots:
+    version: 2.12.0
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
     url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
+    version: 1.11.0

--- a/tutorial_code/http/package.yaml
+++ b/tutorial_code/http/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   certificate_roots:
     url: github.com/toitware/toit-cert-roots
-    version: ^1.6.1
+    version: ^1.11.0
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.7.1
+    version: ^2.12.0

--- a/tutorial_code/i2c/i2c_v1.toit
+++ b/tutorial_code/i2c/i2c_v1.toit
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import i2c
 
 main:
-  scl := gpio.Pin 25
-  sda := gpio.Pin 26
+  scl := 25
+  sda := 26
   frequency := 100_000
 
   bus := i2c.Bus --sda=sda --scl=scl --frequency=frequency

--- a/tutorial_code/i2c/i2c_v2.toit
+++ b/tutorial_code/i2c/i2c_v2.toit
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import i2c
 
 main:
-  scl := gpio.Pin 25
-  sda := gpio.Pin 26
+  scl := 25
+  sda := 26
   frequency := 100_000
 
   bus := i2c.Bus --sda=sda --scl=scl --frequency=frequency

--- a/tutorial_code/mqtt_adafruit/adafruit.toit
+++ b/tutorial_code/mqtt_adafruit/adafruit.toit
@@ -23,9 +23,9 @@ main:
   */
 
   options := mqtt.SessionOptions
-    --client-id = CLIENT-ID
-    --username = ADAFRUIT-IO-USERNAME
-    --password = ADAFRUIT-IO-KEY
+      --client-id = CLIENT-ID
+      --username = ADAFRUIT-IO-USERNAME
+      --password = ADAFRUIT-IO-KEY
 
   client.start --options=options
 

--- a/tutorial_code/mqtt_adafruit/package.lock
+++ b/tutorial_code/mqtt_adafruit/package.lock
@@ -1,15 +1,13 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.170
 prefixes:
-  certificate_roots: toit-cert-roots
-  mqtt: mqtt
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  mqtt: github.com/toitware/mqtt-2
 packages:
-  mqtt:
+  github.com/toitware/mqtt-2:
+    hash: ac50d868a578c45003956da66075be5158a78c7a
     url: github.com/toitware/mqtt
-    name: mqtt
-    version: 2.9.0
-    hash: ab5cda567a9b35e09ec0773ec08f4cb0ee90873d
-  toit-cert-roots:
+    version: 2.13.1
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
     url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
+    version: 1.11.0

--- a/tutorial_code/mqtt_adafruit/package.yaml
+++ b/tutorial_code/mqtt_adafruit/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   certificate_roots:
     url: github.com/toitware/toit-cert-roots
-    version: ^1.6.1
+    version: ^1.11.0
   mqtt:
     url: github.com/toitware/mqtt
-    version: ^2.9.0
+    version: ^2.13.1

--- a/tutorial_code/mqtt_aws/package.lock
+++ b/tutorial_code/mqtt_aws/package.lock
@@ -1,15 +1,13 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.170
 prefixes:
-  certificate_roots: toit-cert-roots
-  mqtt: mqtt
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  mqtt: github.com/toitware/mqtt-2
 packages:
-  mqtt:
+  github.com/toitware/mqtt-2:
+    hash: ac50d868a578c45003956da66075be5158a78c7a
     url: github.com/toitware/mqtt
-    name: mqtt
-    version: 2.9.0
-    hash: ab5cda567a9b35e09ec0773ec08f4cb0ee90873d
-  toit-cert-roots:
+    version: 2.13.1
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
     url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
+    version: 1.11.0

--- a/tutorial_code/mqtt_aws/package.yaml
+++ b/tutorial_code/mqtt_aws/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   certificate_roots:
     url: github.com/toitware/toit-cert-roots
-    version: ^1.6.1
+    version: ^1.11.0
   mqtt:
     url: github.com/toitware/mqtt
-    version: ^2.9.0
+    version: ^2.13.1

--- a/tutorial_code/mqtt_mosquitto/package.lock
+++ b/tutorial_code/mqtt_mosquitto/package.lock
@@ -1,15 +1,13 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.170
 prefixes:
-  certificate_roots: toit-cert-roots
-  mqtt: mqtt
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  mqtt: github.com/toitware/mqtt-2
 packages:
-  mqtt:
+  github.com/toitware/mqtt-2:
+    hash: ac50d868a578c45003956da66075be5158a78c7a
     url: github.com/toitware/mqtt
-    name: mqtt
-    version: 2.8.1
-    hash: 79c44885b4544257e1e2c94c9d1fb4c53e69fbbd
-  toit-cert-roots:
+    version: 2.13.1
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
     url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
+    version: 1.11.0

--- a/tutorial_code/mqtt_mosquitto/package.yaml
+++ b/tutorial_code/mqtt_mosquitto/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   certificate_roots:
     url: github.com/toitware/toit-cert-roots
-    version: ^1.6.1
+    version: ^1.11.0
   mqtt:
     url: github.com/toitware/mqtt
-    version: ^2.8.1
+    version: ^2.13.1

--- a/tutorial_code/mqtt_qubitro/package.lock
+++ b/tutorial_code/mqtt_qubitro/package.lock
@@ -1,28 +1,24 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.170
 prefixes:
-  qubitro: toit-qubitro
+  qubitro: github.com/kasperl/toit-qubitro-0
 packages:
-  mqtt:
-    url: github.com/toitware/mqtt
-    name: mqtt
-    version: 2.8.1
-    hash: 79c44885b4544257e1e2c94c9d1fb4c53e69fbbd
-  toit-artemis:
-    url: github.com/toitware/toit-artemis
-    name: artemis
-    version: 0.8.3
-    hash: c65898c512ec79173b523add1c8d13ec203b6e7e
-  toit-cert-roots:
-    url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
-  toit-qubitro:
-    url: github.com/kasperl/toit-qubitro
-    name: qubitro
-    version: 0.4.0
-    hash: 51dce189860a3d8224ed8ea233c5382b35358845
+  github.com/kasperl/toit-qubitro-0:
+    hash: fb720f5ac40d91e0ae8714f07e8a81c4bf00a3fb
     prefixes:
-      artemis: toit-artemis
-      certificate_roots: toit-cert-roots
-      mqtt: mqtt
+      artemis: github.com/toitware/toit-artemis-0
+      certificate_roots: github.com/toitware/toit-cert-roots-1
+      mqtt: github.com/toitware/mqtt-2
+    url: github.com/kasperl/toit-qubitro
+    version: 0.4.1
+  github.com/toitware/mqtt-2:
+    hash: ac50d868a578c45003956da66075be5158a78c7a
+    url: github.com/toitware/mqtt
+    version: 2.13.1
+  github.com/toitware/toit-artemis-0:
+    hash: c65898c512ec79173b523add1c8d13ec203b6e7e
+    url: github.com/toitware/toit-artemis
+    version: 0.8.3
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
+    url: github.com/toitware/toit-cert-roots
+    version: 1.11.0

--- a/tutorial_code/mqtt_qubitro/package.yaml
+++ b/tutorial_code/mqtt_qubitro/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   qubitro:
     url: github.com/kasperl/toit-qubitro
-    version: ^0.4.0
+    version: ~0.4.1

--- a/tutorial_code/neopixel/neopixel_v1.toit
+++ b/tutorial_code/neopixel/neopixel_v1.toit
@@ -2,14 +2,12 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import pixel-strip show PixelStrip
 
 PIXELS ::= 12
 
 main:
-  pin := gpio.Pin 13
-  strip := PixelStrip.uart PIXELS --pin=pin
+  strip := PixelStrip.uart PIXELS --pin=13
 
   r := ByteArray PIXELS
   g := ByteArray PIXELS

--- a/tutorial_code/neopixel/neopixel_v2.toit
+++ b/tutorial_code/neopixel/neopixel_v2.toit
@@ -6,7 +6,6 @@
 Implements a color wheel animation on a NeoPixel strip.
 */
 
-import gpio
 import pixel-strip show PixelStrip
 
 WHEEL := [
@@ -34,8 +33,7 @@ lerp a/int b/int t/float -> int:
   return (a + t * (b - a)).to-int
 
 main:
-  pin := gpio.Pin 13
-  strip := PixelStrip.uart PIXELS --pin=pin
+  strip := PixelStrip.uart PIXELS --pin=13
 
   r := ByteArray PIXELS
   g := ByteArray PIXELS

--- a/tutorial_code/neopixel/package.lock
+++ b/tutorial_code/neopixel/package.lock
@@ -1,9 +1,8 @@
-sdk: ^2.0.0-alpha.181
+sdk: ^2.0.0-alpha.196
 prefixes:
-  pixel_strip: toit-pixel-strip
+  pixel_strip: github.com/toitware/toit-pixel-strip-1
 packages:
-  toit-pixel-strip:
+  github.com/toitware/toit-pixel-strip-1:
+    hash: e7b0942f6cdc8f5575a3d7e78b74fef1544117c5
     url: github.com/toitware/toit-pixel-strip
-    name: pixel_strip
-    version: 1.3.0
-    hash: 4e7a6027bf6da42a56f052abe8cf33b8b834be55
+    version: 1.4.0

--- a/tutorial_code/neopixel/package.yaml
+++ b/tutorial_code/neopixel/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   pixel_strip:
     url: github.com/toitware/toit-pixel-strip
-    version: ^1.3.0
+    version: ^1.4.0

--- a/tutorial_code/ota/package.lock
+++ b/tutorial_code/ota/package.lock
@@ -1,9 +1,8 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.190
 prefixes:
-  http: pkg-http
+  http: github.com/toitlang/pkg-http-2
 packages:
-  pkg-http:
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
     url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.7.1
-    hash: 54a5bb458d9fc9305e839b878e6de3b456f5c4a6
+    version: 2.12.0

--- a/tutorial_code/ota/package.yaml
+++ b/tutorial_code/ota/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.7.1
+    version: ^2.12.0

--- a/tutorial_code/potentiometer/potentiometer.toit
+++ b/tutorial_code/potentiometer/potentiometer.toit
@@ -2,12 +2,10 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.adc
 
 main:
-  pin := gpio.Pin 34
-  adc := adc.Adc pin
+  adc := adc.Adc 34
   256.repeat:
     print "$(%1.3f adc.get)"
     sleep --ms=500

--- a/tutorial_code/pwm_led/pwm_led_v3.toit
+++ b/tutorial_code/pwm_led/pwm_led_v3.toit
@@ -2,15 +2,12 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.pwm
 
 main:
-  led := gpio.Pin 32
   generator := pwm.Pwm --frequency=400
-  channel := generator.start led
+  channel := generator.start 32
   channel.set-duty-factor 0.5
   sleep --ms=10_000
   channel.close
   generator.close
-  led.close

--- a/tutorial_code/pwm_led/pwm_led_v4.toit
+++ b/tutorial_code/pwm_led/pwm_led_v4.toit
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.pwm
 
 main:
-  led := gpio.Pin 32
   generator := pwm.Pwm --frequency=400
-  channel := generator.start led
+  channel := generator.start 32
   duty-percent := 0
   step := 1
   while true:

--- a/tutorial_code/rotary/main.toit
+++ b/tutorial_code/rotary/main.toit
@@ -6,16 +6,14 @@ DT-PIN ::= 33
 SW-PIN ::= 25
 
 main:
-  // Set up the pins and the counter.
-  clk := gpio.Pin CLK-PIN
-  dt := gpio.Pin DT-PIN
+  // Set up the switch pin and the counter.
   sw := gpio.Pin SW-PIN --input --pull-down
 
   // Since we only need one channel, we can just configure the channel while
   // creating the pulse counter. If multiple channels are changing a
   // counter (unit), then we would need to create a list of channels and pass
   // that to the pulse-counter.Unit constructor.
-  counter := Unit clk --control-pin=dt
+  counter := Unit CLK-PIN --control-pin=DT-PIN
       --on-positive-edge=Channel.EDGE-INCREMENT
       --on-negative-edge=Channel.EDGE-DECREMENT
       --when-control-low=Channel.CONTROL-KEEP

--- a/tutorial_code/secrets/separate_entry_v2/package.lock
+++ b/tutorial_code/secrets/separate_entry_v2/package.lock
@@ -1,9 +1,8 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.188.1
 prefixes:
-  host: pkg-host
+  host: github.com/toitlang/pkg-host-1
 packages:
-  pkg-host:
+  github.com/toitlang/pkg-host-1:
+    hash: d7a30b86c73cf8d9cd5dd0211031c76b68706738
     url: github.com/toitlang/pkg-host
-    name: host
-    version: 1.15.1
-    hash: ff187c2c19d695e66c3dc1d9c09b4dc6bec09088
+    version: 1.19.0

--- a/tutorial_code/secrets/separate_entry_v2/package.yaml
+++ b/tutorial_code/secrets/separate_entry_v2/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.15.1
+    version: ^1.19.0

--- a/tutorial_code/servo/servo_v1.toit
+++ b/tutorial_code/servo/servo_v1.toit
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.pwm
 
 main:
-  servo := gpio.Pin 12
   generator := pwm.Pwm --frequency=50
 
   // Start with the half-way angle.
-  channel := generator.start servo --duty-factor=0.075
+  channel := generator.start 12 --duty-factor=0.075
   sleep --ms=1500
 
   // Max angle.

--- a/tutorial_code/sleep/sleep_v4.toit
+++ b/tutorial_code/sleep/sleep_v4.toit
@@ -3,12 +3,10 @@
 // be found in the LICENSE_BSD0 file.
 
 import esp32
-import gpio
 import gpio.touch as gpio
 
 main:
-  pin := gpio.Pin 32
-  touch := gpio.Touch pin
+  touch := gpio.Touch 32
   touch.threshold = 800
   esp32.enable-touchpad-wakeup
   esp32.deep-sleep (Duration --m=3)

--- a/tutorial_code/ssd1306/package.lock
+++ b/tutorial_code/ssd1306/package.lock
@@ -1,22 +1,26 @@
+sdk: ^2.0.0-alpha.196
 prefixes:
-  pictogrammers_icons: toit-icons-pictogrammers
-  pixel_display: toit-pixel-display
-  ssd1306: toit-ssd1306
+  pictogrammers_icons: github.com/toitware/toit-icons-pictogrammers-1
+  pixel_display: github.com/toitware/toit-pixel-display-2
+  ssd1306: github.com/toitware/toit-ssd1306-2
 packages:
-  toit-icons-pictogrammers:
-    url: github.com/toitware/toit-icons-pictogrammers
-    name: pictogrammers_icons
-    version: 1.0.0
+  github.com/toitware/toit-icons-pictogrammers-1:
     hash: 5ac660cc480d5da1fec72e1b24d425ce978419b7
-  toit-pixel-display:
-    url: github.com/toitware/toit-pixel-display
-    name: pixel_display
-    version: 1.7.1
-    hash: 09bc1b6cf0ae52385af5301a13935a06683a36cf
-  toit-ssd1306:
-    url: github.com/toitware/toit-ssd1306
-    name: ssd1306
-    version: 1.6.0
-    hash: 806c93972b733ff45e10a4eeeefa9a7e5e808c46
+    url: github.com/toitware/toit-icons-pictogrammers
+    version: 1.0.0
+  github.com/toitware/toit-pixel-display-2:
+    hash: 59a4be9f0e6aa2321c6a032da44776f59af364b5
     prefixes:
-      pixel_display: toit-pixel-display
+      png-tools: github.com/toitware/toit-png-tools-1
+    url: github.com/toitware/toit-pixel-display
+    version: 2.11.0
+  github.com/toitware/toit-png-tools-1:
+    hash: ee472ac9d4333a138206f9d3a817d3c5432d6f87
+    url: github.com/toitware/toit-png-tools
+    version: 1.0.0
+  github.com/toitware/toit-ssd1306-2:
+    hash: 444a71ef89a06674c7df5d24754663ec9aeae267
+    prefixes:
+      pixel_display: github.com/toitware/toit-pixel-display-2
+    url: github.com/toitware/toit-ssd1306
+    version: 2.1.0

--- a/tutorial_code/ssd1306/package.yaml
+++ b/tutorial_code/ssd1306/package.yaml
@@ -4,7 +4,7 @@ dependencies:
     version: ^1.0.0
   pixel_display:
     url: github.com/toitware/toit-pixel-display
-    version: ^1.7.1
+    version: ^2.11.0
   ssd1306:
     url: github.com/toitware/toit-ssd1306
-    version: ^1.6.0
+    version: ^2.1.0

--- a/tutorial_code/ssd1306/ssd1306_icon.toit
+++ b/tutorial_code/ssd1306/ssd1306_icon.toit
@@ -8,7 +8,7 @@ import pixel-display show *
 import pixel-display.two-color show *
 import ssd1306 show *
 
-get-display -> TwoColorPixelDisplay:
+get-display -> PixelDisplay:
   sda := 26
   scl := 25
   frequency := 400_000
@@ -21,14 +21,14 @@ get-display -> TwoColorPixelDisplay:
 
   device := bus.device Ssd1306.I2C-ADDRESS
   driver := Ssd1306.i2c device
-  return TwoColorPixelDisplay driver
+  return PixelDisplay.two-color driver
 
 main:
   display := get-display
   display.background = BLACK
 
-  context := display.context --landscape --color=WHITE
-  icon := display.icon context 0 50 icons.HUMAN-SCOOTER
+  icon := Label --x=0 --y=50 --icon=icons.HUMAN-SCOOTER --color=WHITE
+  display.add icon
   while true:
     80.repeat:
       icon.move-to it 50

--- a/tutorial_code/ssd1306/ssd1306_icon.toit
+++ b/tutorial_code/ssd1306/ssd1306_icon.toit
@@ -3,15 +3,14 @@
 // be found in the LICENSE_BSD0 file.
 
 import pictogrammers-icons.size-48 as icons
-import gpio
 import i2c
 import pixel-display show *
 import pixel-display.two-color show *
 import ssd1306 show *
 
 get-display -> TwoColorPixelDisplay:
-  sda := gpio.Pin 26
-  scl := gpio.Pin 25
+  sda := 26
+  scl := 25
   frequency := 400_000
 
   bus := i2c.Bus --sda=sda --scl=scl --frequency=frequency

--- a/tutorial_code/ssd1306/ssd1306_text.toit
+++ b/tutorial_code/ssd1306/ssd1306_text.toit
@@ -29,19 +29,26 @@ main:
 
   device := bus.device Ssd1306.I2C-ADDRESS
   driver := Ssd1306.i2c device
-  display := TwoColorPixelDisplay driver
+  display := PixelDisplay.two-color driver
   display.background = BLACK
 
   sans := Font.get "sans10"
-  sans-context := display.context
-      --landscape
-      --font=sans
-      --color=WHITE
-  display.text sans-context 30 20 "Toit"
-  date := display.text sans-context 30 40 ""
-  time-text := display.text sans-context 30 60 ""
+  [
+    Label --x=30 --y=20 --text="Toit",
+    Label --x=30 --y=40 --id="date",
+    Label --x=30 --y=60 --id="time",
+  ].do: display.add it
+
+  STYLE ::= Style
+      --type-map={
+          "label": Style --font=sans --color=WHITE,
+      }
+  display.set-styles [STYLE]
+
+  date/Label := display.get-element-by-id "date"
+  time/Label := display.get-element-by-id "time"
   while true:
     date.text = current-date
-    time-text.text = current-time
+    time.text = current-time
     display.draw
     sleep --ms=250

--- a/tutorial_code/ssd1306/ssd1306_text.toit
+++ b/tutorial_code/ssd1306/ssd1306_text.toit
@@ -3,7 +3,6 @@
 // be found in the LICENSE_BSD0 file.
 
 import font show *
-import gpio
 import i2c
 import pixel-display show *
 import pixel-display.two-color show *
@@ -18,8 +17,8 @@ current-time:
   return "$(%02d now.h):$(%02d now.m):$(%02d now.s)"
 
 main:
-  sda := gpio.Pin 26
-  scl := gpio.Pin 25
+  sda := 26
+  scl := 25
   frequency := 400_000
 
   bus := i2c.Bus --sda=sda --scl=scl --frequency=frequency

--- a/tutorial_code/supabase/package.lock
+++ b/tutorial_code/supabase/package.lock
@@ -1,28 +1,24 @@
-sdk: ^2.0.0-alpha.150
+sdk: ^2.0.0-alpha.190
 prefixes:
-  certificate-roots: toit-cert-roots
-  supabase: toit-supabase
+  certificate-roots: github.com/toitware/toit-cert-roots-1
+  supabase: github.com/toitware/toit-supabase-0
 packages:
-  pkg-host:
+  github.com/toitlang/pkg-host-1:
+    hash: d7a30b86c73cf8d9cd5dd0211031c76b68706738
     url: github.com/toitlang/pkg-host
-    name: host
-    version: 1.15.3
-    hash: 62393e8522b77eafbafe60b9817935266117daf6
-  pkg-http:
+    version: 1.19.0
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
     url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.8.0
-    hash: 81754d64fe466cd00cc494ec515da8749bf04975
-  toit-cert-roots:
+    version: 2.12.0
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
     url: github.com/toitware/toit-cert-roots
-    name: certificate-roots
-    version: 1.8.0
-    hash: 369a0b36e813e37d6248990de59964020644ab50
-  toit-supabase:
-    url: github.com/toitware/toit-supabase
-    name: supabase
-    version: 0.3.1
+    version: 1.11.0
+  github.com/toitware/toit-supabase-0:
     hash: bcf10850b0fae0592bb0af6563fb994cececb8f9
     prefixes:
-      host: pkg-host
-      http: pkg-http
+      host: github.com/toitlang/pkg-host-1
+      http: github.com/toitlang/pkg-http-2
+    url: github.com/toitware/toit-supabase
+    version: 0.3.1

--- a/tutorial_code/supabase/package.yaml
+++ b/tutorial_code/supabase/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   certificate-roots:
     url: github.com/toitware/toit-cert-roots
-    version: ^1.8.0
+    version: ^1.11.0
   supabase:
     url: github.com/toitware/toit-supabase
-    version: ^0.3.1
+    version: ~0.3.1

--- a/tutorial_code/telegram/package.lock
+++ b/tutorial_code/telegram/package.lock
@@ -1,22 +1,19 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.190
 prefixes:
-  telegram: toit-telegram
+  telegram: github.com/floitsch/toit-telegram-0
 packages:
-  pkg-http:
-    url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.7.1
-    hash: 54a5bb458d9fc9305e839b878e6de3b456f5c4a6
-  toit-cert-roots:
-    url: github.com/toitware/toit-cert-roots
-    name: certificate_roots
-    version: 1.6.1
-    hash: 55d3be82ed53d8d332338b2de931865cf69fe48b
-  toit-telegram:
-    url: github.com/floitsch/toit-telegram
-    name: telegram
-    version: 0.5.3
+  github.com/floitsch/toit-telegram-0:
     hash: 438903d35f6eae1faa7573f5f51b4fa5db3b7dff
     prefixes:
-      certificate_roots: toit-cert-roots
-      http: pkg-http
+      certificate_roots: github.com/toitware/toit-cert-roots-1
+      http: github.com/toitlang/pkg-http-2
+    url: github.com/floitsch/toit-telegram
+    version: 0.5.3
+  github.com/toitlang/pkg-http-2:
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
+    url: github.com/toitlang/pkg-http
+    version: 2.12.0
+  github.com/toitware/toit-cert-roots-1:
+    hash: c117dbba4757d7c69e91af7a875ab6989f051a33
+    url: github.com/toitware/toit-cert-roots
+    version: 1.11.0

--- a/tutorial_code/telegram/package.yaml
+++ b/tutorial_code/telegram/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   telegram:
     url: github.com/floitsch/toit-telegram
-    version: ^0.5.3
+    version: ~0.5.3

--- a/tutorial_code/time/package.lock
+++ b/tutorial_code/time/package.lock
@@ -1,9 +1,8 @@
 sdk: ^2.0.0-alpha.144
 prefixes:
-  ntp: pkg-ntp
+  ntp: github.com/toitlang/pkg-ntp-1
 packages:
-  pkg-ntp:
-    url: github.com/toitlang/pkg-ntp
-    name: ntp
-    version: 1.1.0
+  github.com/toitlang/pkg-ntp-1:
     hash: e69bb1abc0d3d4aa7642eec3360e52744e4d011d
+    url: github.com/toitlang/pkg-ntp
+    version: 1.1.0

--- a/tutorial_code/touch/touch_v1.toit
+++ b/tutorial_code/touch/touch_v1.toit
@@ -2,12 +2,10 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.touch as gpio
 
 main:
-  pin := gpio.Pin 32
-  touch := gpio.Touch pin
+  touch := gpio.Touch 32
 
   while true:
     print (touch.read --raw)

--- a/tutorial_code/touch/touch_v2.toit
+++ b/tutorial_code/touch/touch_v2.toit
@@ -2,12 +2,10 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.touch as gpio
 
 main:
-  pin := gpio.Pin 32
-  touch := gpio.Touch pin
+  touch := gpio.Touch 32
 
   touch.threshold = 800
 

--- a/tutorial_code/touch/touch_v3.toit
+++ b/tutorial_code/touch/touch_v3.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import gpio.touch as gpio
 
 ITERATIONS := 100
@@ -18,8 +17,7 @@ calibrate touch/gpio.Touch:
   touch.threshold = threshold
 
 main:
-  pin := gpio.Pin 32
-  touch := gpio.Touch pin
+  touch := gpio.Touch 32
 
   calibrate touch
 

--- a/tutorial_code/ultra/package.lock
+++ b/tutorial_code/ultra/package.lock
@@ -1,9 +1,14 @@
-sdk: ^2.0.0-alpha.1
+sdk: ^2.0.0-alpha.196
 prefixes:
-  hc_sr04: toit-hc-sr04
+  hc_sr04: github.com/lask/toit-hc-sr04-2
 packages:
-  toit-hc-sr04:
+  github.com/lask/toit-hc-sr04-2:
+    hash: 9a6eb8a69b1dd27351d2ee4994366b584c6d1535
+    prefixes:
+      sensors: github.com/toitware/toit-sensors-1
     url: github.com/lask/toit-hc-sr04
-    name: hc_sr04
-    version: 2.1.1
-    hash: da8389adec9f012999c385b69bc42e26e19b51fa
+    version: 2.3.0
+  github.com/toitware/toit-sensors-1:
+    hash: f9f5662a0f21016259ff6907419e54d00223714a
+    url: github.com/toitware/toit-sensors
+    version: 1.0.0

--- a/tutorial_code/ultra/package.yaml
+++ b/tutorial_code/ultra/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   hc_sr04:
     url: github.com/lask/toit-hc-sr04
-    version: ^2.1.1
+    version: ^2.3.0

--- a/tutorial_code/ultra/ultra_v2.toit
+++ b/tutorial_code/ultra/ultra_v2.toit
@@ -2,16 +2,13 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the LICENSE_BSD0 file.
 
-import gpio
 import hc-sr04
 
 TRIGGER ::= 33
 ECHO ::= 32
 
 main:
-  trigger := gpio.Pin TRIGGER
-  echo := gpio.Pin ECHO
-  sensor := hc-sr04.Driver --echo=echo --trigger=trigger
+  sensor := hc-sr04.Driver --echo=ECHO --trigger=TRIGGER
 
   while true:
     distance := sensor.read-distance

--- a/tutorial_code/watchdog/package.lock
+++ b/tutorial_code/watchdog/package.lock
@@ -1,9 +1,8 @@
 sdk: ^2.0.0-alpha.118
 prefixes:
-  watchdog: toit-watchdog
+  watchdog: github.com/toitware/toit-watchdog-1
 packages:
-  toit-watchdog:
+  github.com/toitware/toit-watchdog-1:
+    hash: 2621b25fca45f4f91c0b951f3658f3c18821edc4
     url: github.com/toitware/toit-watchdog
-    name: watchdog
-    version: 1.4.0
-    hash: 3dccabf427af3a8ba3ef48429244ece0956fa684
+    version: 1.4.1

--- a/tutorial_code/watchdog/package.yaml
+++ b/tutorial_code/watchdog/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   watchdog:
     url: github.com/toitware/toit-watchdog
-    version: ^1.4.0
+    version: ^1.4.1


### PR DESCRIPTION
## Summary

- migrate tutorial snippets and checked-in tutorial code to integer GPIO arguments
- update tutorial and snippet-check dependencies to their latest available releases
- update SSD1306 examples for the current pixel-display API
- run hardware-only snippets in analyze mode and pin CI to Toit v2.0.0-alpha.197

## Validation

- analyzed all tutorial Toit sources with -Werror using alpha.196
- ran the affected documentation snippet checks
- verified updated tools and SSD1306 lockfiles install cleanly
- ran git diff --check

Alpha.197 was released after local validation; CI may temporarily fail while release binaries propagate.